### PR TITLE
Treat multiprocessing module as optional

### DIFF
--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -1,6 +1,11 @@
-import sys
 import traceback
-import multiprocessing
+
+try:
+    import multiprocessing
+    USE_MULTIPROCESSING = True
+except ImportError:
+    USE_MULTIPROCESSING = False
+
 import platform
 from datetime import datetime
 
@@ -21,7 +26,9 @@ class RaygunMessageBuilder:
 
     def set_environment_details(self):
         self.raygunMessage.details['environment'] = {
-            "processorCount": multiprocessing.cpu_count(),
+            "processorCount": (
+                multiprocessing.cpu_count() if USE_MULTIPROCESSING else "n/a"
+            ),
             "architecture": platform.architecture()[0],
             "cpu": platform.processor(),
             "oSVersion": "%s %s" % (platform.system(), platform.release())

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -1,6 +1,11 @@
-import sys
 import traceback
-import multiprocessing
+
+try:
+    import multiprocessing
+    USE_MULTIPROCESSING = True
+except ImportError:
+    USE_MULTIPROCESSING = False
+
 import platform
 from datetime import datetime
 
@@ -21,7 +26,9 @@ class RaygunMessageBuilder:
 
     def set_environment_details(self):
         self.raygunMessage.details['environment'] = {
-            "processorCount": multiprocessing.cpu_count(),
+            "processorCount": (
+                multiprocessing.cpu_count() if USE_MULTIPROCESSING else "n/a"
+            ),
             "architecture": platform.architecture()[0],
             "cpu": platform.processor(),
             "oSVersion": "%s %s" % (platform.system(), platform.release())


### PR DESCRIPTION
Environments such as Google App Engine do not provide access to Python's multiprocessing module. The changes in this branch account for that.