### PR TITLE
Make methodName extraction more cautious

### DIFF
--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -123,9 +123,11 @@ class RaygunErrorMessage:
                         'lineNumber': frame[2],
                         'className': frame[3],
                         'fileName': frame[1],
-                        'methodName': frame[4][0],
+                        'methodName': frame[4][0] if frame[4] is not None else None,
                         'localVariables': self._get_locals(frame[0]) if 'transmitLocalVariables' in options and options['transmitLocalVariables'] is True else None
                     })
+        except:
+            pass
         finally:
             del frames
 

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -126,8 +126,6 @@ class RaygunErrorMessage:
                         'methodName': frame[4][0] if frame[4] is not None else None,
                         'localVariables': self._get_locals(frame[0]) if 'transmitLocalVariables' in options and options['transmitLocalVariables'] is True else None
                     })
-        except:
-            pass
         finally:
             del frames
 

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -127,7 +127,7 @@ class RaygunErrorMessage:
                         'lineNumber': frame[2],
                         'className': frame[3],
                         'fileName': frame[1],
-                        'methodName': frame[4][0],
+                        'methodName': frame[4][0] if frame[4] is not None else None,
                         'localVariables': self._get_locals(frame[0]) if 'transmitLocalVariables' in options and options['transmitLocalVariables'] is True else None
                     })
         finally:


### PR DESCRIPTION
Using the terrifically fast Falcon Framework (http://falconframework.org) I came across an issue trying to integrate Raygun, in that because much of Falcon is C with Python wrappings, elements of stack traces are not always where they are meant to be -- namely a value of `None` at `frame[4]` for a given stack frame in that range. Because of that, `frame[4][0]` was throwing an error, and therefore Raygun itself was throwing an exception and not reporting the exceptions it was catching in the first place!

Hopefully this little change is good without tests -- I don't know how to test it outside of synthesizing a stack trace of this sort, and I have no idea how to do that, at least not from the top of my head.

Let me know if there's anything I can contribute.