### PR TITLE
Allow for more flexible configuration from Django.

### DIFF
--- a/python2/raygun4py/middleware/django.py
+++ b/python2/raygun4py/middleware/django.py
@@ -7,8 +7,10 @@ from raygun4py import raygunprovider
 class Provider(object):
 
     def __init__(self):
-    	apiKey = getattr(settings, 'RAYGUN4PY_API_KEY', None)
-        self.sender = raygunprovider.RaygunSender(apiKey)
+    	config = getattr(settings, 'RAYGUN4PY_CONFIG', {})
+    	apiKey = getattr(settings, 'RAYGUN4PY_API_KEY', config.get('api_key', None))
+    	
+        self.sender = raygunprovider.RaygunSender(apiKey, config=config)
 
     def process_exception(self, request, exception):
     	raygunRequest = self._mapRequest(request)

--- a/python2/raygun4py/middleware/django.py
+++ b/python2/raygun4py/middleware/django.py
@@ -24,6 +24,12 @@ class Provider(object):
             if not k.startswith('wsgi'):
                 _headers[k] = v
 
+        raw_data = ''
+        if hasattr(request, 'body'):
+            raw_data = request.body
+        elif hasattr(request, 'raw_post_data'):
+            raw_data = request.raw_post_data
+
         return {
             'hostName': request.get_host(),
             'url': request.path,
@@ -32,5 +38,5 @@ class Provider(object):
             'queryString': dict((key, request.GET[key]) for key in request.GET),
             'form': dict((key, request.POST[key]) for key in request.POST),
             'headers': _headers,
-            'rawData': request.body if hasattr(request, 'body') else request.raw_post_data
+            'rawData': raw_data
         }

--- a/python2/raygun4py/utilities.py
+++ b/python2/raygun4py/utilities.py
@@ -23,3 +23,17 @@ def filter_keys(filteredKeys, object):
             iterationTarget[key] = filter_keys(filteredKeys, iterationTarget[key])
 
     return iterationTarget
+
+
+def camel(k):
+    "Turns snake_case_strings into camelCaseStrings."
+    if k.lower() != k:
+        return k  # Don't transform camelCase value, it's good to go.
+    new_key = k.replace('_', ' ').title().replace(' ', '')
+    return new_key[0].lower() + new_key[1:]
+
+
+def camelize_dict(d):
+    return dict([
+        (camel(k), v) for k, v in d.items()
+    ])


### PR DESCRIPTION
This PR has 2 goals.

First, to allow for more flexibility, I modified the `RaygunSender` class to take more of its initial values from the `config` dictionary that is passed to it upon instantiation.  It assumes that there's a one-to-one mapping from snake_cased key names in the config dictionary to camelCased attributes on the `RaygunSender` instance that the API already knows how to use.

Second, to make use of that flexibility, I modified the `raygun4py.middleware.django.Provider` class to take more of its configuration from the conventional Django location of `settings.py`.  Instead of merely looking for `RAYGUN4PY_API_KEY`, Provider now looks for a `RAYGUN4PY_CONFIG` dictionary, which is then passed into the (now more flexible) `RaygunSender` class.

Prior to these changes, if you wanted to change any of the sender options, you had to write custom code.   This is still an option of course, but simple changes like specifying a set of keys to filter out of the raygun message can be specified via a configuration option in settings.py.

I've run this in local development and it works just fine.  If this seems like a valuable thing for you to have upstream, I can modify the README to show how to use the config option to greater effect.