### PR TITLE
Fix #23: Use repr on localvars instead of str.

### DIFF
--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -142,5 +142,5 @@ class RaygunErrorMessage:
 
         if '__traceback_hide__' not in localVars:
             for key in localVars:
-                result[key] = str(localVars[key])
+                result[key] = repr(localVars[key])
             return result

--- a/python2/tests/test_functional.py
+++ b/python2/tests/test_functional.py
@@ -242,6 +242,18 @@ class TestRaygun4PyFunctional(unittest.TestCase):
 
             self.assertEqual(result[0], 202)
 
+    def test_utf8_unicode_localvariable(self):
+        client = raygunprovider.RaygunSender(self.apiKey)
+
+        theVariable = u'\xc2\xa2'
+
+        try:
+            raise Exception("Raygun4py2: utf8 local variable")
+        except Exception as e:
+            result = client.send_exception(httpRequest={})
+
+            self.assertEqual(result[0], 202)
+
     def test_bytestring_localvariable(self):
       client = raygunprovider.RaygunSender(self.apiKey)
 


### PR DESCRIPTION
When converting localvars into a readable format, str() fails to decode
unicode strings (as opposed to strings with unicode bytes, which is what
is currently tested). unicode() will also fail without being told an
encoding, and we can't assume that everything is utf8. repr() works for
all values and seems like a better choice for these values anyway.