### PR TITLE
Handle str() conversion errors.

### DIFF
--- a/python2/raygun4py/middleware/django.py
+++ b/python2/raygun4py/middleware/django.py
@@ -30,5 +30,5 @@ class Provider(object):
             'queryString': dict((key, request.GET[key]) for key in request.GET),
             'form': dict((key, request.POST[key]) for key in request.POST),
             'headers': _headers,
-            'rawData': request.body if hasattr(request, 'body') else request.raw_post_data
+            'rawData': request.body if hasattr(request, 'body') else getattr(request, 'raw_post_data', {})
         }

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -142,5 +142,13 @@ class RaygunErrorMessage:
 
         if '__traceback_hide__' not in localVars:
             for key in localVars:
-                result[key] = str(localVars[key])
+                try:
+                    # Note that str() *can* fail; thus protect against it as much as we can.
+                    result[key] = str(localVars[key])
+                except Exception as e:
+                    try:
+                        r = repr(localVars[key])
+                    except Exception as re:
+                        r = "Couldn't convert to repr due to {0}".format(re)
+                    result[key] = "!!! Couldn't convert {0!r} (repr: {1}) due to {2!r} !!!".format(key, r, e)
             return result

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -155,5 +155,13 @@ class RaygunErrorMessage:
 
         if '__traceback_hide__' not in localVars:
             for key in localVars:
-                result[key] = str(localVars[key])
+                try:
+                    # Note that str() *can* fail; thus protect against it as much as we can.
+                    result[key] = str(localVars[key])
+                except Exception as e:
+                    try:
+                        r = repr(localVars[key])
+                    except Exception as re:
+                        r = "Couldn't convert to repr due to {0}".format(re)
+                    result[key] = "!!! Couldn't convert {0!r} (repr: {1}) due to {2!r} !!!".format(key, r, e)
             return result


### PR DESCRIPTION
Currently, if a value can't be str()'d, then the entire error report
is lost due to the exception propagating up the stack.

That's not really desirable; instead, note that conversion failed, and
still send the report.