### PR TITLE
Fix #28: Log errors and warnings instead of printing them.

### DIFF
--- a/python2/raygun4py/middleware/flask.py
+++ b/python2/raygun4py/middleware/flask.py
@@ -1,8 +1,14 @@
 from __future__ import absolute_import
 
+import logging
+
 from flask.signals import got_request_exception
 
 from raygun4py import raygunprovider
+
+
+log = logging.getLogger(__name__)
+
 
 class Provider(object):
 
@@ -22,6 +28,6 @@ class Provider(object):
 
 	def send_exception(self, *args, **kwargs):
 		if not self.sender:
-			print >> sys.stderr, ("Raygun-Flask: Cannot send as provider not attached")
+			log.error("Raygun-Flask: Cannot send as provider not attached")
 
 		self.sender.send_exception()

--- a/python2/raygun4py/middleware/wsgi.py
+++ b/python2/raygun4py/middleware/wsgi.py
@@ -1,4 +1,10 @@
+import logging
+
 from raygun4py import raygunprovider
+
+
+log = logging.getLogger(__name__)
+
 
 class Provider(object):
 
@@ -8,7 +14,7 @@ class Provider(object):
 
     def __call__(self, environ, start_response):
         if not self.sender:
-            print >> sys.stderr, ("Raygun-WSGI: Cannot send as provider not attached")
+            log.error("Raygun-WSGI: Cannot send as provider not attached")
 
         try:
             chunk = self.app(environ, start_response)

--- a/python2/raygun4py/raygunprovider.py
+++ b/python2/raygun4py/raygunprovider.py
@@ -8,6 +8,9 @@ from raygun4py import raygunmsgs
 from raygun4py import utilities
 
 
+log = logging.getLogger(__name__)
+
+
 class RaygunSender:
 
     apiKey = None
@@ -18,13 +21,13 @@ class RaygunSender:
         if (apiKey):
             self.apiKey = apiKey
         else:
-            print >> sys.stderr, "RaygunProvider error: ApiKey not set, errors will not be transmitted"
+            log.warning("RaygunProvider error: ApiKey not set, errors will not be transmitted")
 
         try:
             import ssl
         except ImportError:
-            print >> sys.stderr, ("RaygunProvider error: No SSL support available, cannot send. Please"
-                                  "compile the socket module with SSL support.")
+            log.warning("RaygunProvider error: No SSL support available, cannot send. Please"
+                        "compile the socket module with SSL support.")
         self.userversion = "Not defined"
         self.user = None
         self.ignoredExceptions = []
@@ -148,7 +151,7 @@ class RaygunSender:
             conn.request('POST', self.endpointpath, json, headers)
             response = conn.getresponse()
         except Exception as e:
-            print e
+            log.error(e)
             return 400, "Exception: Could not send"
         return response.status, response.reason
 

--- a/python3/raygun4py/raygunprovider.py
+++ b/python3/raygun4py/raygunprovider.py
@@ -18,13 +18,13 @@ class RaygunSender:
         if (apiKey):
             self.apiKey = apiKey
         else:
-            print >> sys.stderr, "RaygunProvider error: ApiKey not set, errors will not be transmitted"
+            log.warning("RaygunProvider error: ApiKey not set, errors will not be transmitted")
 
         try:
             import ssl
         except ImportError:
-            print >> sys.stderr, ("RaygunProvider error: No SSL support available, cannot send. Please"
-                                  "compile the socket module with SSL support.")
+            log.warning("RaygunProvider error: No SSL support available, cannot send. Please"
+                        "compile the socket module with SSL support.")
         self.userversion = "Not defined"
         self.user = None
         self.ignoredExceptions = []
@@ -149,7 +149,7 @@ class RaygunSender:
             response = conn.getresponse()
             conn.close()
         except Exception as e:
-            print(e)
+            log.error(e)
             return 400, "Exception: Could not send"
         return response.status, response.reason
 


### PR DESCRIPTION
Now we can filter and redirect these messages! Yay!

I was unsure of whether to add tests for these logging messages, and decided not to given that there are some future improvements that may make some of them obsolete, like raising an exception for unrecoverable errors (like when Provider.sender is null) or not even bothering to attempt to send to Raygun if there's no API key (assuming that is, in fact, an error).