### PR TITLE
tags attribute fix

### DIFF
--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -60,7 +60,7 @@ class RaygunMessageBuilder:
 
     def set_tags(self, tags):
         if type(tags) is list or tuple:
-            self.raygunMessage.details['tags'] = tags
+            self.raygunMessage.details['Tags'] = tags
         return self
 
     def set_request_details(self, request):


### PR DESCRIPTION
Hello.
A minor bugfix.
As working with colleagues with raygun integration for slack we noticed, that tags, generated in .net projects, ar displayed, while the ones, generated in python projects, ar not. As comparing post requests we noticed, that these requests are different by their attribute keys. python keys are lowercase. By making it uppercase, python generated error exceptions tags are now displayed in slack.