### PR TITLE
crash during _get_locals error reporting

### DIFF
--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -142,5 +142,8 @@ class RaygunErrorMessage:
 
         if '__traceback_hide__' not in localVars:
             for key in localVars:
-                result[key] = str(localVars[key])
+                try:
+                    result[key] = unicode(localVars[key])
+                except:
+                    pass
             return result


### PR DESCRIPTION
some local variable values may not be encoded by ascii, try to use unicode instead, and do not error when failed to encode

please also fix this in the python3 version, this bug is very critical because when exception happens, the error report never makes it to raygun !!!