### PR TITLE
do not access os.environ.data directly.

### DIFF
--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -36,7 +36,7 @@ class RaygunMessageBuilder:
             "architecture": platform.architecture()[0],
             "cpu": platform.processor(),
             "oSVersion": "%s %s" % (platform.system(), platform.release()),
-            "environmentVariables": os.environ.data,
+            "environmentVariables": dict(os.environ),
             "runtimeLocation": sys.executable,
             "runtimeVersion": 'Python ' + sys.version
         }

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -29,10 +29,6 @@ class RaygunMessageBuilder:
         return self
 
     def set_environment_details(self, extra_environment_data):
-        env = {}
-        for key in os.environ.keys():
-            env[key] = os.environ[key]
-
         self.raygunMessage.details['environment'] = {
             "processorCount": (
                 multiprocessing.cpu_count() if USE_MULTIPROCESSING else "n/a"
@@ -40,7 +36,7 @@ class RaygunMessageBuilder:
             "architecture": platform.architecture()[0],
             "cpu": platform.processor(),
             "oSVersion": "%s %s" % (platform.system(), platform.release()),
-            "environmentVariables": env,
+            "environmentVariables": dict(os.environ),
             "runtimeLocation": sys.executable,
             "runtimeVersion": 'Python ' + sys.version
         }


### PR DESCRIPTION
This PR updates handling of access to os.environ. On App Engine, attempting to access os.environ.data can result in the following error: `AttributeError: 'RequestLocalEnviron' object has no attribute 'data'`. Also slightly simplified the dictionary generation in the Python 3 version.
