### PR TITLE
Adding Django 1.10 Fix

### DIFF
--- a/python3/raygun4py/middleware/django.py
+++ b/python3/raygun4py/middleware/django.py
@@ -12,15 +12,11 @@ class Provider(MiddlewareMixin):
 
     def __init__(self, get_response=None):
         super().__init__(get_response)
-        # self.get_response = get_response
 
         config = getattr(settings, 'RAYGUN4PY_CONFIG', {})
         apiKey = getattr(settings, 'RAYGUN4PY_API_KEY', config.get('api_key', None))
 
         self.sender = raygunprovider.RaygunSender(apiKey, config=config)
-
-
-
 
     def process_exception(self, request, exception):
         raygun_request = self._mapRequest(request)

--- a/python3/raygun4py/middleware/django.py
+++ b/python3/raygun4py/middleware/django.py
@@ -1,15 +1,26 @@
 import django
 from django.conf import settings
 from raygun4py import raygunprovider
+from django.utils.functional import cached_property
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
 
-class Provider(object):
+class Provider(MiddlewareMixin):
 
-    def __init__(self):
+    def __init__(self, get_response=None):
+        super().__init__(get_response)
+        # self.get_response = get_response
+
         config = getattr(settings, 'RAYGUN4PY_CONFIG', {})
         apiKey = getattr(settings, 'RAYGUN4PY_API_KEY', config.get('api_key', None))
 
         self.sender = raygunprovider.RaygunSender(apiKey, config=config)
+
+
+
 
     def process_exception(self, request, exception):
         raygun_request = self._mapRequest(request)


### PR DESCRIPTION
## Purpose
Django 1.10 changed the way Middleware functions. Using raygun4py 3.1.4 with Python 3 and Django 1.10 results in a TypeError (same problem as documented in [this](http://stackoverflow.com/questions/38792686/installation-of-django-debug-toolbar-typeerror-init-takes-1-positional-a) SO question).

Following the Django docs [here](https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-middleware), I used the deprecation MiddlewareMixin and a pattern similar to the one used in the fix for django-debug-toolbar. This resolves the `TypeError` but results in `RecursionError`.

I'll keep digging around but wanted to toss this half-finished fix in a PR in case someone else was looking at the same problem.

## Related Findings
Looks like v3.1.0 added support for Py3 here: https://github.com/MindscapeHQ/raygun4py/pull/37. Couldn't find any mention of Django 1.10
Similar Django Debug Toolbar issue: https://github.com/jazzband/django-debug-toolbar/issues/853