### PR TITLE
fix issue with getting HTTP_HOST in wsgi middleware

### DIFF
--- a/python2/raygun4py/middleware/wsgi.py
+++ b/python2/raygun4py/middleware/wsgi.py
@@ -40,7 +40,7 @@ class Provider(object):
     def build_request(self, environ):
         request = {}
 
-        http_host = environ.get(['HTTP_HOST'], None)
+        http_host = environ.get('HTTP_HOST', None)
         if http_host is not None:
             http_host = http_host.replace(' ', '')
 


### PR DESCRIPTION
While integrating the wsgi middleware with a pylons app, there was an error looking up the HTTP_HOST. The issue is that arrays can't be used to lookup a dictionary value.

I would appreciate any guidance on how to get this contributed back upstream.