### PR TITLE
Fixed documentation for function client.filter_keys(keys=[])

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -255,7 +255,7 @@ Config and data functions
 +--------------------+---------------+--------------------+
 | Function           | Arguments     | Type               |
 +====================+===============+====================+
-| filtered_keys      | keys          | List               |
+| filter_keys        | keys          | List               |
 +--------------------+---------------+--------------------+
 
 If you want to filter sensitive data out of the payload that is sent to Raygun, pass in a list of keys here. Any matching keys on the top level Raygun message object, or within dictionaries on the top level Raygun message object (including dictionaries nested within dictionaries) will have their value replaced with :code:`<filtered>` - useful for passwords, credit card data etc.


### PR DESCRIPTION
client.filtered_keys is a property and is a list.
client.filter_keys(keys=[]) is the actual function that should be referenced there.