### PR TITLE
Improving support for WSGI request handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ lib
 lib64
 
 venv
+venv2
+venv27
 
 # Installer logs
 pip-log.txt
@@ -37,3 +39,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# VSCode
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 
 cache: pip
 
-python: ["2.6", "2.7", "3.2", "3.3", "3.4", "3.5", "3.6", "pypy"]
+python: ["2.7", "3.2", "3.3", "3.4", "3.5", "3.6", "pypy"]
 
 install:
   - pip install jsonpickle

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -2,7 +2,7 @@
 The following will show you how to get started with local development
 
 ## Python 2
-1. `cd <project folder> && virtualenv -p <PATH TO PYTHON2> venv2
+1. `cd <project folder> && virtualenv -p <PATH TO PYTHON2> venv2`
 2. activate the virtual env
 3. `python setup.py develop`
 4.

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -11,7 +11,10 @@ pip install unittest2
 pip install mock
 pip install 'django==1.8.8'
 ```
-5.
+5. Run tests
+```
+cd python2 && unit2
+```
 
 ## Python 3
 ...TODO

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,0 +1,17 @@
+# Getting Started with Local Development
+The following will show you how to get started with local development
+
+## Python 2
+1. `cd <project folder> && virtualenv -p <PATH TO PYTHON2> venv2
+2. activate the virtual env
+3. `python setup.py develop`
+4.
+```
+pip install unittest2
+pip install mock
+pip install 'django==1.8.8'
+```
+5.
+
+## Python 3
+...TODO

--- a/python2/raygun4py/http_utilities.py
+++ b/python2/raygun4py/http_utilities.py
@@ -45,9 +45,20 @@ def build_wsgi_compliant_request(request):
 
         for key, value in request.items():
             if key.startswith('HTTP_'):
-                _headers[key] = value
+                # 'HTTP_REFERER' => 'Referer'
+                new_key = http_environ_var_to_header_key(key)
+                _headers[new_key] = value
 
     # force the values to be a dictionary as some frameworks don't treat them that way
     rg_request['headers'] = dict(_headers)
 
     return rg_request
+
+
+def http_environ_var_to_header_key(key):
+    "turns HTTP_REFERER like keys into Referer"
+    parts = key.split('_')
+    if parts[0] == "HTTP":
+        parts.pop(0)
+
+    return '-'.join([x.title() for x in parts])

--- a/python2/raygun4py/http_utilities.py
+++ b/python2/raygun4py/http_utilities.py
@@ -1,0 +1,53 @@
+
+
+def build_wsgi_compliant_request(request):
+    if not request:
+        return self
+
+    # start with WSGI environ variables, then overlay the specific, expected
+    # httpRequest keys for RG API compat
+    # https://www.python.org/dev/peps/pep-3333/#environ-variables
+
+    http_host = request.get('hostName') \
+                or request.get('HTTP_HOST') \
+                or "{}:{}".format(request.get('SERVER_NAME'), request.get('SERVER_PORT'))
+
+    if http_host is not None:
+        http_host = http_host.replace(' ', '')
+
+    # TODO, better understand how to "properly" fallback to wsgi.input stream
+    http_form = request.get('form') or request.get('wsgi.input')
+    if http_form is not None:
+        http_form = dict(http_form)
+
+    try:
+        rg_request = {
+            'httpMethod': (request.get('httpMethod') or request.get('REQUEST_METHOD')),
+            'url': (request.get('url') or request.get('PATH_INFO')),
+            'hostName': http_host,
+            'iPAddress': (request.get('ipAddress') or request.get('iPAddress') or request.get('REMOTE_ADDR')),
+            'queryString': (request.get('queryString') or request.get('QUERY_STRING')),
+            'headers': {}, # see below
+            'form': http_form,
+            'rawData': {}
+        }
+    except Exception:
+        pass
+
+    # Header processing
+    _headers = request.get('headers')
+    if _headers is None:
+        # manually try to build up headers given known WSGI keys
+        _headers = {
+            'Content-Type': request.get('CONTENT_TYPE'),
+            'Content-Length': request.get('CONTENT_LENGTH'),
+        }
+
+        for key, value in request.items():
+            if key.startswith('HTTP_'):
+                _headers[key] = value
+
+    # force the values to be a dictionary as some frameworks don't treat them that way
+    rg_request['headers'] = dict(_headers)
+
+    return rg_request

--- a/python2/raygun4py/middleware/wsgi.py
+++ b/python2/raygun4py/middleware/wsgi.py
@@ -1,6 +1,6 @@
 import logging
 
-from raygun4py import raygunprovider
+from raygun4py import raygunprovider, http_utilities
 
 
 log = logging.getLogger(__name__)
@@ -33,33 +33,7 @@ class Provider(object):
                 try:
                     iterable.close()
                 except Exception as e:
-                    request = self.build_request(environ)
+                    rg_request_details = http_utilities.build_wsgi_compliant_request(environ)
                     self.sender.send_exception(exception=e, request=request)
                     raise
 
-    def build_request(self, environ):
-        request = {}
-
-        http_host = environ.get('HTTP_HOST', None)
-        if http_host is not None:
-            http_host = http_host.replace(' ', '')
-
-        try:
-            request = {
-                'httpMethod': environ.get('REQUEST_METHOD', None),
-                'url': environ.get('PATH_INFO', None),
-                'ipAddress': environ.get('REMOTE_ADDR', None),
-                'hostName': http_host,
-                'queryString': environ.get('QUERY_STRING', None),
-                'headers': {},
-                'form': {},
-                'rawData': {}
-            }
-        except Exception:
-            pass
-
-        for key, value in environ.items():
-            if key.startswith('HTTP_'):
-               request['headers'][key] = value
-
-        return request

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -187,12 +187,3 @@ class RaygunErrorMessage(object):
                         r = "Couldn't convert to repr due to {0}".format(re)
                     result[key] = "!!! Couldn't convert {0!r} (repr: {1}) due to {2!r} !!!".format(key, r, e)
             return result
-
-def get_with_fallbacks(dict, keys_to_try):
-    val = None
-    for i in range(len(keys_to_try)):
-        val = dict.get(keys_to_try[i])
-        if val is not None:
-            break
-
-    return val

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -11,6 +11,7 @@ except ImportError:
 
 import platform
 from datetime import datetime
+from raygun4py import http_utilities
 
 
 class RaygunMessageBuilder(object):
@@ -89,21 +90,11 @@ class RaygunMessageBuilder(object):
         return self
 
     def set_request_details(self, request):
-        if request:
-            self.raygunMessage.details['request'] = {
-                "hostName": request['hostName'],
-                "url": request['url'],
-                "httpMethod": request['httpMethod'],
-                "queryString": request['queryString'],
-                "form": request['form'],
-                "headers": request['headers'],
-                "rawData": request['rawData']
-            }
+        if not request:
+            return self
 
-            if 'ipAddress' in request:
-                self.raygunMessage.details['request']['iPAddress'] = request['ipAddress']
-            elif 'iPAddress' in request:
-                self.raygunMessage.details['request']['iPAddress'] = request['iPAddress']
+        rg_request_details = http_utilities.build_wsgi_compliant_request(request)
+        self.raygunMessage.details['request'] = rg_request_details
 
         return self
 
@@ -196,3 +187,12 @@ class RaygunErrorMessage(object):
                         r = "Couldn't convert to repr due to {0}".format(re)
                     result[key] = "!!! Couldn't convert {0!r} (repr: {1}) due to {2!r} !!!".format(key, r, e)
             return result
+
+def get_with_fallbacks(dict, keys_to_try):
+    val = None
+    for i in range(len(keys_to_try)):
+        val = dict.get(keys_to_try[i])
+        if val is not None:
+            break
+
+    return val

--- a/python2/tests/test_raygunmsgs.py
+++ b/python2/tests/test_raygunmsgs.py
@@ -37,6 +37,7 @@ class TestRaygunMessageBuilder(unittest.TestCase):
             "HTTP_CACHE_CONTROL": "no-cache",
             "HTTP_ACCEPT": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
             "HTTP_USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+            "HTTP_REFERER": "https://www.google.com/",
             "HTTP_CONNECTION": "keep-alive",
             "SERVER_NAME": "localhost",
             "REMOTE_ADDR": "127.0.0.1",
@@ -103,6 +104,14 @@ class TestRaygunMessageBuilder(unittest.TestCase):
         self.assertEqual(self.builder.raygunMessage.details['request']['url'], '/resource-wsgi')
         self.assertEqual(self.builder.raygunMessage.details['request']['httpMethod'], 'GET')
         self.assertEqual(self.builder.raygunMessage.details['request']['queryString'], 'query=testme')
+
+    def test_wsgi_standard_header_names(self):
+        self.builder.set_request_details(self.raw_wsgi_request)
+        self.assertEqual(self.builder.raygunMessage.details['request']['headers']['User-Agent'],
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36")
+        self.assertEqual(self.builder.raygunMessage.details['request']['headers']['Referer'],
+                        "https://www.google.com/")
+
 
 class TestRaygunErrorMessage(unittest.TestCase):
     class ParentError(Exception):


### PR DESCRIPTION
Hi

We have a few apps running WSGI-based frameworks (Pyramid, Flask) on Python 2.7 runtimes. The following changes are bits of logic we've had internal to our codebases that we'd like to contribute up-stream.

The primary goals of this PR are as follows: 
- consolidate the logic for extracting critical values from HTTP request objects (WSGI environ, and Pyramid/Flask request)
- Try to use the expected `request` properties if they are present, but then safely fall back to standard WSGI environ properties
- Don't fail with key errors when trying to do things like: 
```
"hostName": request['hostName']
``` 