### PR TITLE
Set version

### DIFF
--- a/python2/raygun4py/__init__.py
+++ b/python2/raygun4py/__init__.py
@@ -1,0 +1,1 @@
+from .version import __version__

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -2,6 +2,7 @@ import sys
 import os
 import inspect
 import jsonpickle
+from version import __version__
 
 try:
     import multiprocessing
@@ -74,7 +75,7 @@ class RaygunMessageBuilder(object):
     def set_client_details(self):
         self.raygunMessage.details['client'] = {
             "name": "raygun4py",
-            "version": "3.1.3",
+            "version": __version__,
             "clientUrl": "https://github.com/MindscapeHQ/raygun4py"
         }
         return self

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -2,7 +2,7 @@ import sys
 import os
 import inspect
 import jsonpickle
-from version import __version__
+from raygun4py import __version__
 
 try:
     import multiprocessing

--- a/python2/raygun4py/version.py
+++ b/python2/raygun4py/version.py
@@ -1,0 +1,5 @@
+# Store the version here so:
+# 1) we don't load dependencies by storing it in __init__.py
+# 2) we can import it in setup.py for the same reason
+# 3) we can import it into your module module
+__version__ = '4.2.1'

--- a/python2/tests/test_raygunprovider.py
+++ b/python2/tests/test_raygunprovider.py
@@ -3,7 +3,8 @@ import unittest2 as unittest
 from raygun4py import raygunprovider
 from raygun4py import raygunmsgs
 from raygun4py import utilities
-
+from raygun4py import __version__
+from raygun4py import version as version_file
 
 class TestRaygunSender(unittest.TestCase):
 
@@ -23,7 +24,7 @@ class TestRaygunSender(unittest.TestCase):
     def test_sending_403_with_invalid_key(self):
         try:
             raise StandardError('test')
-        except Exception as e:            
+        except Exception as e:
             info = sys.exc_info()
             http_result = self.sender.send_exception(info)
             self.assertEqual(http_result[0], 403)
@@ -72,6 +73,9 @@ class TestRaygunSender(unittest.TestCase):
     def test_default_global_variables(self):
         self.sender = raygunprovider.RaygunSender('foo')
         self.assertTrue(self.sender.transmit_global_variables)
+
+    def test_module_version_matches(self):
+        self.assertEqual(__version__, version_file.__version__)
 
 
 class TestGroupingKey(unittest.TestCase):

--- a/python3/raygun4py/__init__.py
+++ b/python3/raygun4py/__init__.py
@@ -1,0 +1,1 @@
+from .version import __version__

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -2,6 +2,7 @@ import sys
 import os
 import inspect
 import jsonpickle
+from version import __version__
 
 try:
     import multiprocessing
@@ -74,7 +75,7 @@ class RaygunMessageBuilder(object):
     def set_client_details(self):
         self.raygunMessage.details['client'] = {
             "name": "raygun4py",
-            "version": "3.1.3",
+            "version": __version__,
             "clientUrl": "https://github.com/MindscapeHQ/raygun4py"
         }
         return self

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -2,7 +2,7 @@ import sys
 import os
 import inspect
 import jsonpickle
-from version import __version__
+from raygun4py import __version__
 
 try:
     import multiprocessing

--- a/python3/raygun4py/version.py
+++ b/python3/raygun4py/version.py
@@ -1,0 +1,5 @@
+# Store the version here so:
+# 1) we don't load dependencies by storing it in __init__.py
+# 2) we can import it in setup.py for the same reason
+# 3) we can import it into your module module
+__version__ = '4.2.1'

--- a/python3/tests/test_raygunprovider.py
+++ b/python3/tests/test_raygunprovider.py
@@ -2,6 +2,8 @@ import unittest, sys
 from raygun4py import raygunprovider
 from raygun4py import raygunmsgs
 from raygun4py import utilities
+from raygun4py import __version__
+from raygun4py import version as version_file
 
 
 class TestRaygunSender(unittest.TestCase):
@@ -72,6 +74,9 @@ class TestRaygunSender(unittest.TestCase):
     def test_default_global_variables(self):
         self.sender = raygunprovider.RaygunSender('foo')
         self.assertTrue(self.sender.transmit_global_variables)
+
+    def test_module_version_matches(self):
+        self.assertEqual(__version__, version_file.__version__)
 
 
 class TestGroupingKey(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,11 @@ from setuptools import setup
 
 packages = ['raygun4py', 'raygun4py.middleware']
 
-if sys.version_info[0] == 2:
-    base_dir = 'python2'
-elif sys.version_info[0] == 3:
+base_dir = 'python2'
+if sys.version_info[0] == 3:
     base_dir = 'python3'
 
+exec(open('%s/raygun4py/version.py' % base_dir).read())
 requirements = [
     'jsonpickle >= 0.9.2',
     'blinker >= 1.3.0',
@@ -25,7 +25,7 @@ dev_requirements = [
 
 setup(
     name='raygun4py',
-    version='4.2.0',
+    version=__version__,
     packages=packages,
     package_dir= {
         "raygun4py": base_dir + "/raygun4py"


### PR DESCRIPTION
This PR exposes the `__version__` attribute on the module, and fixes an issue where all errors were getting reported as the raygun4py module version of 3.1.3. It is setup separately in each of the python2 and python3 modules, so you could use different version for each if you choose to do that down the road.

I've bumped the version to 4.2.1, and made an attempt at unit tests. 

EDIT: Should add that I was following some suggested practices around version in python libraries from [this Stack Overflow response](https://stackoverflow.com/a/16084844/2083544)