### PR TITLE
Flask middleware changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ nosetests.xml
 
 # VSCode
 .vscode
+
+# IntelliJ
+.idea

--- a/python2/raygun4py/middleware/flask.py
+++ b/python2/raygun4py/middleware/flask.py
@@ -14,6 +14,7 @@ class Provider(object):
     def __init__(self, flaskApp, apiKey):
         self.flaskApp = flaskApp
         self.apiKey = apiKey
+        self.sender = None
 
         got_request_exception.connect(self.send_exception, sender=flaskApp)
 
@@ -24,6 +25,7 @@ class Provider(object):
             self.flaskApp.extensions = {}
 
         self.sender = raygunprovider.RaygunSender(self.apiKey)
+        return self.sender
 
     def send_exception(self, *args, **kwargs):
         if not self.sender:

--- a/python3/raygun4py/middleware/flask.py
+++ b/python3/raygun4py/middleware/flask.py
@@ -10,6 +10,7 @@ class Provider(object):
     def __init__(self, flaskApp, apiKey):
         self.flaskApp = flaskApp
         self.apiKey = apiKey
+        self.sender = None
 
         got_request_exception.connect(self.send_exception, sender=flaskApp)
 
@@ -20,6 +21,7 @@ class Provider(object):
             self.flaskApp.extensions = {}
 
         self.sender = raygunprovider.RaygunSender(self.apiKey)
+        return self.sender
 
     def send_exception(self, *args, **kwargs):
         if not self.sender:


### PR DESCRIPTION
I ran into an issue when I was trying to set the version for a flask app. 

Here are some steps that outline the issue:

This fails since the provider isn't returned
```
from raygun4py.middleware import flask as raygunFlask

raygun_client = raygunFlask.Provider(app, CONFIG.RAYGUN_API_KEY).attach()
raygun_client.set_version(os.environ.get('VERSION')) 
```

This is the workaround that has to be done now, but doesn't seem intuitive to have to use the sender attribute

```
raygun_client = raygunFlask.Provider(app, CONFIG.RAYGUN_API_KEY)
raygun_client.attach()
raygun_client.sender.set_version(os.environ.get('VERSION'))
```

With the changes I'm opening in this PR, you could do the following, and it is backwards compatible with how I'm doing it above:
```
raygun_client = raygunFlask.Provider(app, CONFIG.RAYGUN_API_KEY).attach()
raygun_client.set_version(os.environ.get('VERSION'))
```