### PR TITLE
Add rawData to the build_wsgi_compliant_request function

### DIFF
--- a/python2/raygun4py/http_utilities.py
+++ b/python2/raygun4py/http_utilities.py
@@ -34,7 +34,7 @@ def build_wsgi_compliant_request(request):
             'queryString': (request.get('queryString') or request.get('QUERY_STRING')),
             'headers': {}, # see below
             'form': http_form,
-            'rawData': {}
+            'rawData': request.get('rawData')
         }
     except Exception:
         pass

--- a/python3/raygun4py/http_utilities.py
+++ b/python3/raygun4py/http_utilities.py
@@ -34,7 +34,7 @@ def build_wsgi_compliant_request(request):
             'queryString': (request.get('queryString') or request.get('QUERY_STRING')),
             'headers': {}, # see below
             'form': http_form,
-            'rawData': {}
+            'rawData': request.get('rawData')
         }
     except Exception:
         pass


### PR DESCRIPTION
## Overview

Raw request data was not coming through when being sent manually as the value was being overwritten to an empty dict in the build_wsgi_compliant_request function.

## Updates 

- Add rawData to Python 2+3 to functions in http utilities