### PR TITLE
docs: Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ settings.py
 
 .. code:: python
 
-  MIDDLEWARE_CLASSES = (
+  MIDDLEWARE = (
       'raygun4py.middleware.django.Provider'
   )
 


### PR DESCRIPTION
Change MIDDLEWARE_CLASSES to MIDDLEWARE, https://docs.djangoproject.com/en/1.10/topics/http/middleware/#writing-your-own-middleware

```
Changed in Django 1.10:
A new style of middleware was introduced for use with the new MIDDLEWARE setting. 
If you’re using the old MIDDLEWARE_CLASSES setting, you’ll need to adapt old, custom middleware before using the new setting. 
This document describes new-style middleware. Refer to this page in older versions of the documentation for a description of how old-style middleware works.
```