### PR TITLE
Config option to not include environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.3.0 (06/06/2019):
+Features:
+  - Added a new config option, `transmit_environment_variables`, to control sending any environment variables at all
+  - Added support to `filter_keys` config option for ignoring keys with a simple wildcard approach. See README for more information
+
 ## 4.2.3 (28/03/2019):
 Bugfixes
   - Add request rawData to the build_wsgi_compliant_request utilities to fix a bug where rawData is set manually then overwritten by an empty object.

--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,7 @@ The above configuration is the minimal required setup. The full set of options s
       'ignored_exceptions': [],
       'transmit_global_variables': True,
       'transmit_local_variables': True,
+      'transmit_environment_variables:': True,
       'userversion': "Not defined",
       'user': None
   }
@@ -195,11 +196,12 @@ Initialization options
       'ignored_exceptions': [],
       'transmit_global_variables': True,
       'transmit_local_variables': True,
+      'transmit_environment_variables:': True,
       'userversion': "Not defined",
       'user': None
   })
 
-For the local/global variables, if their options are set to False the corresponding variables will not be sent with exception payloads.
+For the local/global/environment variables, if their options are set to False the corresponding variables will not be sent with exception payloads.
 
 httpTimeout controls the maximum time the HTTP request can take when POSTing to the Raygun API, and is of type 'float'.
 

--- a/README.rst
+++ b/README.rst
@@ -260,7 +260,7 @@ Config and data functions
 | filter_keys        | keys          | List               |
 +--------------------+---------------+--------------------+
 
-If you want to filter sensitive data out of the payload that is sent to Raygun, pass in a list of keys here. Any matching keys on the top level Raygun message object, or within dictionaries on the top level Raygun message object (including dictionaries nested within dictionaries) will have their value replaced with :code:`<filtered>` - useful for passwords, credit card data etc.
+If you want to filter sensitive data out of the payload that is sent to Raygun, pass in a list of keys here. Any matching keys on the top level Raygun message object, or within dictionaries on the top level Raygun message object (including dictionaries nested within dictionaries) will have their value replaced with :code:`<filtered>` - useful for passwords, credit card data etc. Supports * at the end of a key to indicate you want to filter any key that contains that key, ie foo_* will filter foo_bar, foo_qux, foo_baz etc
 
 +------------------+---------------+--------------------+
 | Function         | Arguments     | Type               |

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -17,11 +17,12 @@ from raygun4py import http_utilities
 
 class RaygunMessageBuilder(object):
 
-    def __init__(self):
+    def __init__(self, options):
         self.raygunMessage = RaygunMessage()
+        self.options = options
 
     def new(self):
-        return RaygunMessageBuilder()
+        return RaygunMessageBuilder(self.options)
 
     def build(self):
         return self.raygunMessage
@@ -36,6 +37,9 @@ class RaygunMessageBuilder(object):
             "runtimeLocation": sys.executable,
             "runtimeVersion": 'Python ' + sys.version
         }
+
+        if self.options.get('transmit_environment_variables', True) is False:
+            self.raygunMessage.details['environment']['environmentVariables'] = None
 
         # Wrap these so we gracefully fail if we cannot access the system details for any reason
         try:

--- a/python2/raygun4py/raygunprovider.py
+++ b/python2/raygun4py/raygunprovider.py
@@ -18,6 +18,7 @@ DEFAULT_CONFIG = {
     'proxy': None,
     'transmit_global_variables': True,
     'transmit_local_variables': True,
+    'transmit_environment_variables': True,
     'userversion': "Not defined",
     'user': None,
     'http_timeout': 10.0
@@ -123,7 +124,11 @@ class RaygunSender:
         return tags, custom_data, http_request, extra_environment_data
 
     def _create_message(self, raygunExceptionMessage, tags, user_custom_data, http_request, extra_environment_data):
-        return raygunmsgs.RaygunMessageBuilder().new() \
+        options = {
+            'transmit_environment_variables': self.transmit_environment_variables
+        }
+
+        return raygunmsgs.RaygunMessageBuilder(options).new() \
             .set_machine_name(socket.gethostname()) \
             .set_version(self.userversion) \
             .set_client_details() \

--- a/python2/raygun4py/utilities.py
+++ b/python2/raygun4py/utilities.py
@@ -16,11 +16,18 @@ def filter_keys(filtered_keys, object):
         iteration_target = object.__dict__
 
     for key in iteration_target.iterkeys():
-        if key in filtered_keys:
-            iteration_target[key] = '<filtered>'
-
-        elif isinstance(iteration_target[key], dict):
+        if isinstance(iteration_target[key], dict):
             iteration_target[key] = filter_keys(filtered_keys, iteration_target[key])
+        else:
+            for filter_key in filtered_keys:
+                if key in filtered_keys:
+                    iteration_target[key] = '<filtered>'
+                elif '*' in filter_key:
+                    sanitised_key = filter_key.replace('*', '')
+
+                    if sanitised_key in key:
+                        iteration_target[key] = '<filtered>'
+
 
     return iteration_target
 

--- a/python2/raygun4py/version.py
+++ b/python2/raygun4py/version.py
@@ -2,4 +2,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
-__version__ = '4.2.3'
+__version__ = '4.3.0'

--- a/python2/tests/test_raygunmsgs.py
+++ b/python2/tests/test_raygunmsgs.py
@@ -8,7 +8,7 @@ from raygun4py import raygunmsgs
 class TestRaygunMessageBuilder(unittest.TestCase):
 
     def setUp(self):
-        self.builder = raygunmsgs.RaygunMessageBuilder().new()
+        self.builder = raygunmsgs.RaygunMessageBuilder({}).new()
         self.request = {
             "headers": {
                 "referer": "localhost",
@@ -111,6 +111,19 @@ class TestRaygunMessageBuilder(unittest.TestCase):
                         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36")
         self.assertEqual(self.builder.raygunMessage.details['request']['headers']['Referer'],
                         "https://www.google.com/")
+
+    def test_environment_variables(self):
+        self.builder.set_environment_details(None)
+
+        self.assertIsNotNone(self.builder.raygunMessage.details['environment']['environmentVariables'])
+
+    def test_environment_variables_are_ignored(self):
+        self.builder.options = {
+            'transmit_environment_variables': False
+        }
+        self.builder.set_environment_details(None)
+
+        self.assertIsNone(self.builder.raygunMessage.details['environment']['environmentVariables'])
 
 
 class TestRaygunErrorMessage(unittest.TestCase):

--- a/python2/tests/test_raygunprovider.py
+++ b/python2/tests/test_raygunprovider.py
@@ -86,7 +86,7 @@ class TestGroupingKey(unittest.TestCase):
     def create_dummy_message(self):
         self.sender = raygunprovider.RaygunSender('apikey')
 
-        msg = raygunmsgs.RaygunMessageBuilder().new()
+        msg = raygunmsgs.RaygunMessageBuilder({}).new()
         errorMessage = raygunmsgs.RaygunErrorMessage(Exception, None, None, {})
         msg.set_exception_details(errorMessage)
         return msg.build()

--- a/python2/tests/test_utilities.py
+++ b/python2/tests/test_utilities.py
@@ -1,0 +1,52 @@
+import sys
+import unittest2 as unittest
+import socket
+import inspect
+
+from raygun4py import utilities
+
+class TestRaygunUtilities(unittest.TestCase):
+    def test_filter_keys(self):
+        test_obj = {
+            'foo': 'bar',
+            'baz': 'qux'
+        }
+
+        utilities.filter_keys(['foo'], test_obj)
+
+        self.assertEqual(test_obj['foo'], '<filtered>')
+
+    def test_filter_keys_recursive(self):
+        test_obj = {
+            'foo': 'bar',
+            'baz': 'qux',
+            'boo': {
+                'foo': 'qux'
+            }
+        }
+
+        utilities.filter_keys(['foo'], test_obj)
+
+        self.assertEqual(test_obj['foo'], '<filtered>')
+        self.assertEqual(test_obj['boo']['foo'], '<filtered>')
+
+
+    def test_filter_keys_with_wildcard(self):
+        test_obj = {
+            'foobr': 'bar',
+            'foobz': 'baz',
+            'fooqx': 'foo',
+            'baz': 'qux'
+        }
+
+        utilities.filter_keys(['foo*'], test_obj)
+
+        self.assertEqual(test_obj['foobr'], '<filtered>')
+        self.assertEqual(test_obj['foobz'], '<filtered>')
+        self.assertEqual(test_obj['fooqx'], '<filtered>')
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -17,11 +17,12 @@ from raygun4py import http_utilities
 
 class RaygunMessageBuilder(object):
 
-    def __init__(self):
+    def __init__(self, options):
         self.raygunMessage = RaygunMessage()
+        self.options = options
 
     def new(self):
-        return RaygunMessageBuilder()
+        return RaygunMessageBuilder(self.options)
 
     def build(self):
         return self.raygunMessage
@@ -36,6 +37,9 @@ class RaygunMessageBuilder(object):
             "runtimeLocation": sys.executable,
             "runtimeVersion": 'Python ' + sys.version
         }
+
+        if self.options.get('transmit_environment_variables', True) is False:
+            self.raygunMessage.details['environment']['environmentVariables'] = None
 
         # Wrap these so we gracefully fail if we cannot access the system details for any reason
         try:

--- a/python3/raygun4py/raygunprovider.py
+++ b/python3/raygun4py/raygunprovider.py
@@ -15,6 +15,7 @@ DEFAULT_CONFIG = {
     'proxy': None,
     'transmit_global_variables': True,
     'transmit_local_variables': True,
+    'transmit_environment_variables': True,
     'userversion': "Not defined",
     'user': None,
     'http_timeout': 10.0
@@ -113,7 +114,11 @@ class RaygunSender:
         return tags, custom_data, http_request, extra_environment_data
 
     def _create_message(self, raygunExceptionMessage, tags, user_custom_data, http_request, extra_environment_data):
-        return raygunmsgs.RaygunMessageBuilder().new() \
+        options = {
+            'transmit_environment_variables': self.transmit_environment_variables
+        }
+
+        return raygunmsgs.RaygunMessageBuilder(options).new() \
             .set_machine_name(socket.gethostname()) \
             .set_version(self.userversion) \
             .set_client_details() \

--- a/python3/raygun4py/utilities.py
+++ b/python3/raygun4py/utilities.py
@@ -16,11 +16,18 @@ def filter_keys(filtered_keys, object):
         iteration_target = object.__dict__
 
     for key in iter(iteration_target.keys()):
-        if key in filtered_keys:
-            iteration_target[key] = '<filtered>'
-
-        elif isinstance(iteration_target[key], dict):
+        if isinstance(iteration_target[key], dict):
             iteration_target[key] = filter_keys(filtered_keys, iteration_target[key])
+        else:
+            for filter_key in filtered_keys:
+                if key in filtered_keys:
+                    iteration_target[key] = '<filtered>'
+                elif '*' in filter_key:
+                    sanitised_key = filter_key.replace('*', '')
+
+                    if sanitised_key in key:
+                        iteration_target[key] = '<filtered>'
+
 
     return iteration_target
 

--- a/python3/raygun4py/version.py
+++ b/python3/raygun4py/version.py
@@ -2,4 +2,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
-__version__ = '4.2.3'
+__version__ = '4.3.0'

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -5,7 +5,7 @@ from raygun4py import raygunmsgs
 class TestRaygunMessageBuilder(unittest.TestCase):
 
     def setUp(self):
-        self.builder = raygunmsgs.RaygunMessageBuilder().new()
+        self.builder = raygunmsgs.RaygunMessageBuilder({}).new()
         self.request = {
             "headers": {
                 "referer": "localhost",
@@ -113,6 +113,19 @@ class TestRaygunMessageBuilder(unittest.TestCase):
         self.builder \
                 .set_request_details(self.raw_wsgi_request) \
                 .set_tags(['foo', 'bar'])
+
+    def test_environment_variables(self):
+        self.builder.set_environment_details(None)
+
+        self.assertIsNotNone(self.builder.raygunMessage.details['environment']['environmentVariables'])
+
+    def test_environment_variables_are_ignored(self):
+        self.builder.options = {
+            'transmit_environment_variables': False
+        }
+        self.builder.set_environment_details(None)
+
+        self.assertIsNone(self.builder.raygunMessage.details['environment']['environmentVariables'])
 
 
 class TestRaygunErrorMessage(unittest.TestCase):

--- a/python3/tests/test_raygunprovider.py
+++ b/python3/tests/test_raygunprovider.py
@@ -87,7 +87,7 @@ class TestGroupingKey(unittest.TestCase):
     def create_dummy_message(self):
         self.sender = raygunprovider.RaygunSender('apikey')
 
-        msg = raygunmsgs.RaygunMessageBuilder().new()
+        msg = raygunmsgs.RaygunMessageBuilder({}).new()
         errorMessage = raygunmsgs.RaygunErrorMessage(Exception, None, None, {})
         msg.set_exception_details(errorMessage)
         return msg.build()

--- a/python3/tests/test_utilities.py
+++ b/python3/tests/test_utilities.py
@@ -1,0 +1,51 @@
+import unittest, sys
+import socket
+import inspect
+
+from raygun4py import utilities
+
+class TestRaygunUtilities(unittest.TestCase):
+    def test_filter_keys(self):
+        test_obj = {
+            'foo': 'bar',
+            'baz': 'qux'
+        }
+
+        utilities.filter_keys(['foo'], test_obj)
+
+        self.assertEqual(test_obj['foo'], '<filtered>')
+
+    def test_filter_keys_recursive(self):
+        test_obj = {
+            'foo': 'bar',
+            'baz': 'qux',
+            'boo': {
+                'foo': 'qux'
+            }
+        }
+
+        utilities.filter_keys(['foo'], test_obj)
+
+        self.assertEqual(test_obj['foo'], '<filtered>')
+        self.assertEqual(test_obj['boo']['foo'], '<filtered>')
+
+
+    def test_filter_keys_with_wildcard(self):
+        test_obj = {
+            'foobr': 'bar',
+            'foobz': 'baz',
+            'fooqx': 'foo',
+            'baz': 'qux'
+        }
+
+        utilities.filter_keys(['foo*'], test_obj)
+
+        self.assertEqual(test_obj['foobr'], '<filtered>')
+        self.assertEqual(test_obj['foobz'], '<filtered>')
+        self.assertEqual(test_obj['fooqx'], '<filtered>')
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This adds a config option to not include any environment variables in the payload sent to Raygun.

I've also updated the filter_keys method to support a simple wildcard approach

Fixes #85, #88 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindscapehq/raygun4py/87)
<!-- Reviewable:end -->
