### PR TITLE
Feature - Enable inspect package `stack()` as acceptable `send_exception` traceback parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python: ["2.7", "3.2", "3.3", "3.4", "3.5", "3.6", "pypy"]
 matrix:
   include:
     - python: 3.7
-      dist: xenial
+      dist: trusty
       sudo: true
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,13 @@ language: python
 
 cache: pip
 
-python: ["2.7", "3.2", "3.3", "3.4", "3.5", "3.6", "pypy"]
+python: ["2.7", "3.4", "3.5", "3.6", "pypy"]
 
 # Workaround to install Python 3.7
 # https://github.com/travis-ci/travis-ci/issues/9815
 matrix:
   include:
     - python: 3.7
-      dist: xenial
-      sudo: true
-
-matrix:
-  include:
-    - python: 3.2
-      dist: xenial
-      sudo: true
-
-matrix:
-  include:
-    - python: 3.3
       dist: xenial
       sudo: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,15 @@ matrix:
     - python: 3.2
       dist: trusty
       sudo: true
+
+matrix:
+  include:
     - python: 3.3
       dist: trusty
       sudo: true
+
+matrix:
+  include:
     - python: 3.7
       dist: xenial
       sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 
 cache: pip
 
-python: ["2.7", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "pypy"]
+python: ["2.7", "3.4", "3.5", "3.6", "pypy"]
 
 dist: trusty
 
@@ -12,8 +12,13 @@ dist: trusty
 # https://github.com/travis-ci/travis-ci/issues/9815
 matrix:
   include:
-    - name: "Python 3.7"
-      python: "3.7"
+    - python: 3.2
+      dist: trusty
+      sudo: true
+    - python: 3.3
+      dist: trusty
+      sudo: true
+    - python: 3.7
       dist: xenial
       sudo: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 
 cache: pip
 
-python: ["2.7", "3.4", "3.5", "3.6", "pypy"]
+python: ["2.7", "3.2", "3.3", "3.4", "3.5", "3.6", "pypy"]
 
 # Workaround to install Python 3.7
 # https://github.com/travis-ci/travis-ci/issues/9815
@@ -16,6 +16,7 @@ matrix:
 
 install:
   - pip install .[dev]
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 || $TRAVIS_PYTHON_VERSION == 3.2 ]]; then pip install virtualenv==15.2.0 tox==3.1.3; fi
 
 script:
   # Django 1.8 requires Python 2.7+

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,14 @@ language: python
 
 cache: pip
 
-python: ["2.7", "3.2", "3.3", "3.4", "3.5", "3.6", "pypy"]
+python: ["2.7", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "pypy"]
 
-os: linux
 dist: trusty
 
 # Workaround to install Python 3.7
 # https://github.com/travis-ci/travis-ci/issues/9815
 matrix:
   include:
-    - name: "Python 3.2"
-      python: "3.2"
-      dist: trusty
-    - name: "Python 3.3"
-      python: "3.3"
-      dist: trusty
     - name: "Python 3.7"
       python: "3.7"
       dist: xenial
@@ -26,7 +19,6 @@ matrix:
 
 install:
   - pip install .[dev]
-  # - if [[ $TRAVIS_PYTHON_VERSION == 3.3 || $TRAVIS_PYTHON_VERSION == 3.2 ]]; then pip install virtualenv==15.2.0 tox==3.1.3; fi
 
 script:
   # Django 1.8 requires Python 2.7+

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,8 @@ matrix:
   include:
     - python: 3.2
       dist: trusty
-      sudo: true
     - python: 3.3
       dist: trusty
-      sudo: true
     - python: 3.7
       dist: xenial
       sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 
 cache: pip
 
-python: ["2.7", "3.4", "3.5", "3.6", "pypy"]
+python: ["2.7", "3.2", "3.3", "3.4", "3.5", "3.6", "pypy"]
 
 # Workaround to install Python 3.7
 # https://github.com/travis-ci/travis-ci/issues/9815

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ cache: pip
 
 python: ["2.7", "3.2", "3.3", "3.4", "3.5", "3.6", "pypy"]
 
-os:
-  - linux
+os: linux
+dist: trusty
 
 # Workaround to install Python 3.7
 # https://github.com/travis-ci/travis-ci/issues/9815

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,18 @@ matrix:
       dist: xenial
       sudo: true
 
+matrix:
+  include:
+    - python: 3.2
+      dist: xenial
+      sudo: true
+
+matrix:
+  include:
+    - python: 3.3
+      dist: xenial
+      sudo: true
+
 install:
   - pip install .[dev]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 
 cache: pip
 
-python: ["2.7", "3.2", "3.3", "3.4", "3.5", "3.6", "pypy"]
+python: ["2.7", "3.4", "3.5", "3.6", "pypy"]
 
 # Workaround to install Python 3.7
 # https://github.com/travis-ci/travis-ci/issues/9815

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ cache: pip
 
 python: ["2.7", "3.4", "3.5", "3.6", "pypy"]
 
-dist: trusty
-
 # Workaround to install Python 3.7
 # https://github.com/travis-ci/travis-ci/issues/9815
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,14 @@ python: ["2.7", "3.2", "3.3", "3.4", "3.5", "3.6", "pypy"]
 # https://github.com/travis-ci/travis-ci/issues/9815
 matrix:
   include:
-    - python: 3.7
+    - python: 3.2
       dist: trusty
+      sudo: true
+    - python: 3.3
+      dist: trusty
+      sudo: true
+    - python: 3.7
+      dist: xenial
       sudo: true
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,29 +6,27 @@ cache: pip
 
 python: ["2.7", "3.2", "3.3", "3.4", "3.5", "3.6", "pypy"]
 
+os:
+  - linux
+
 # Workaround to install Python 3.7
 # https://github.com/travis-ci/travis-ci/issues/9815
 matrix:
   include:
-    - python: 3.2
+    - name: "Python 3.2"
+      python: "3.2"
       dist: trusty
-      sudo: true
-
-matrix:
-  include:
-    - python: 3.3
+    - name: "Python 3.3"
+      python: "3.3"
       dist: trusty
-      sudo: true
-
-matrix:
-  include:
-    - python: 3.7
+    - name: "Python 3.7"
+      python: "3.7"
       dist: xenial
       sudo: true
 
 install:
   - pip install .[dev]
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 || $TRAVIS_PYTHON_VERSION == 3.2 ]]; then pip install virtualenv==15.2.0 tox==3.1.3; fi
+  # - if [[ $TRAVIS_PYTHON_VERSION == 3.3 || $TRAVIS_PYTHON_VERSION == 3.2 ]]; then pip install virtualenv==15.2.0 tox==3.1.3; fi
 
 script:
   # Django 1.8 requires Python 2.7+

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -3,6 +3,8 @@ The following will show you how to get started with local development
 
 ## Python 2
 1. `cd <project folder> && virtualenv -p <PATH TO PYTHON2> venv2`
+ 
+   (Example: `virtualenv -p $(which python) venv2` )
 1. activate the virtual env
 1. `pip install .[dev]`
 1. Run tests

--- a/README.rst
+++ b/README.rst
@@ -240,6 +240,12 @@ Call this function from within a catch block to send the current exception to Ra
   # Send tags, custom data and an HTTP request object
   httpResult = client.send_exception(tags=[], userCustomData={}, request={})
 
+  # Send custom traceback
+  exception = ValueError("new error")
+  mutated_stack = inspect.stack()
+  # modify mutated_stack.append(...)
+  httpResult = client.send_exception(exc_info=[type(exception), exception, mutated_stack])
+
 You can pass in **either** of these two exception params:
 
 * :code:`exception` should be a subclass of type Exception. Pass this in if you want to manually transmit an exception object to Raygun.

--- a/README.rst
+++ b/README.rst
@@ -242,7 +242,7 @@ Call this function from within a catch block to send the current exception to Ra
 
   # Send custom traceback, or a full traceback using `inspect.stack()`
   exception = ValueError("new error")
-  # inspect's stack() will have all local variables from stacks proceeding it (which a rescued exception might not have the full picture).
+  # inspect's stack() will have all local variables from stacks proceeding it (which a rescued exception may not have the full picture).
   new_stack = inspect.stack()
   httpResult = client.send_exception(exc_info=[type(exception), exception, new_stack])
 

--- a/README.rst
+++ b/README.rst
@@ -242,9 +242,10 @@ Call this function from within a catch block to send the current exception to Ra
 
   # Send custom traceback
   exception = ValueError("new error")
-  mutated_stack = inspect.stack()
-  # modify mutated_stack.append(...)
-  httpResult = client.send_exception(exc_info=[type(exception), exception, mutated_stack])
+  new_stack = inspect.stack()
+  # You can even modify the stack:
+  # new_stack = new_stack.append(...)
+  httpResult = client.send_exception(exc_info=[type(exception), exception, new_stack])
 
 You can pass in **either** of these two exception params:
 

--- a/README.rst
+++ b/README.rst
@@ -242,7 +242,7 @@ Call this function from within a catch block to send the current exception to Ra
 
   # Send custom traceback, or a full traceback using `inspect.stack()`
   exception = ValueError("new error")
-  # inspect's stack() will have all local variables from stacks above, which a rescued exception may not.
+  # inspect's stack() will have all local variables from stacks proceeding it (which a rescued exception might not have the full picture).
   new_stack = inspect.stack()
   httpResult = client.send_exception(exc_info=[type(exception), exception, new_stack])
 

--- a/README.rst
+++ b/README.rst
@@ -240,11 +240,10 @@ Call this function from within a catch block to send the current exception to Ra
   # Send tags, custom data and an HTTP request object
   httpResult = client.send_exception(tags=[], userCustomData={}, request={})
 
-  # Send custom traceback
+  # Send custom traceback, or a full traceback using `inspect.stack()`
   exception = ValueError("new error")
+  # inspect's stack() will have all local variables from stacks above, which a rescued exception may not.
   new_stack = inspect.stack()
-  # You can even modify the stack:
-  # new_stack = new_stack.append(...)
   httpResult = client.send_exception(exc_info=[type(exception), exception, new_stack])
 
 You can pass in **either** of these two exception params:

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -183,6 +183,12 @@ class RaygunErrorMessage(object):
             return inspect.getinnerframes(exc_traceback)
 
     def _is_stack_frame_type(self, exc_traceback):
+        # Try not to search through entire string, (which could be an entire stack trace) by truncating to 100.
+        # "<frame" should be found within the first 50 characters.
+        # Example:
+        # >>> str(inspect.stack()).lower()[0:50]
+        #     "[frameinfo(frame=<frame at 0x1074b8528, file '<std"
+        #
         short_traceback = str(exc_traceback).lower()[0:100]
         is_found = re.search(self.INSPECT_FRAME_TYPE_SIGNATURE, short_traceback)
         return is_found

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -135,8 +135,7 @@ class RaygunErrorMessage(object):
 
         frames = None
         try:
-
-            if type(exc_traceback) == list and type(exc_traceback[0]) == tuple and 'frame' in str(exc_traceback[0][0].__class__).lower():
+            if type(exc_traceback) == list and type(exc_traceback[0]) == tuple and 'frame' in str(type(exc_traceback[0][0])).lower():
                 frames = exc_traceback
             else:
                 frames = inspect.getinnerframes(exc_traceback)

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -15,6 +15,10 @@ from datetime import datetime
 from raygun4py import http_utilities
 
 
+class DeveloperException(Exception):
+    pass
+
+
 class RaygunMessageBuilder(object):
 
     def __init__(self, options):
@@ -191,7 +195,7 @@ class RaygunErrorMessage(object):
                 return False
             else:
                 if not inspect.isframe(frame[0]):
-                    return False
+                    raise DeveloperException("Expected frame type. Got '{}' instead.".format(type(frame[0])))
 
         return True
 

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -135,7 +135,10 @@ class RaygunErrorMessage(object):
 
         frames = None
         try:
-            frames = inspect.getinnerframes(exc_traceback)
+            if type(exc_traceback) == list and type(exc_traceback[0]) == tuple and str(exc_traceback[0][0].__class__) == "<type 'frame'>":
+                frames = exc_traceback
+            else:
+                frames = inspect.getinnerframes(exc_traceback)
 
             if frames:
                 for frame in frames:
@@ -181,10 +184,7 @@ class RaygunErrorMessage(object):
             for key in localVars:
                 try:
                     # Note that str() *can* fail; thus protect against it as much as we can.
-                    if type(localVars[key]) is unicode:
-                        result[key] = localVars[key]
-                    else:
-                        result[key] = str(localVars[key])
+                    result[key] = str(localVars[key])
                 except Exception as e:
                     try:
                         r = repr(localVars[key])

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -133,7 +133,6 @@ class RaygunErrorMessage(object):
         self.message = "%s: %s" % (exc_type.__name__, exc_value)
         self.stackTrace = []
 
-        frames = None
         try:
             frames = self._get_frames(exc_traceback)
 

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -136,6 +136,7 @@ class RaygunErrorMessage(object):
         self.message = "%s: %s" % (exc_type.__name__, exc_value)
         self.stackTrace = []
 
+        frames = None
         try:
             frames = self._get_frames(exc_traceback)
 
@@ -182,11 +183,8 @@ class RaygunErrorMessage(object):
             return inspect.getinnerframes(exc_traceback)
 
     def _is_stack_frame_type(self, exc_traceback):
-        try:
-            matches = re.findall(INSPECT_FRAME_TYPE_REGEX, str(exc_traceback).lower())
-            return len(matches) > 1
-        except Exception as e:
-            return False
+        matches = re.findall(self.INSPECT_FRAME_TYPE_SIGNATURE, str(exc_traceback).lower())
+        return len(matches) >= 1
 
     def _get_locals(self, frame):
         result = {}

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -181,10 +181,13 @@ class RaygunErrorMessage(object):
         return self.className
 
     def _get_frames(self, exc_traceback):
+        if not exc_traceback or inspect.istraceback(exc_traceback):
+            return inspect.getinnerframes(exc_traceback)
+
         if self._is_stack_frame_type(exc_traceback):
             return exc_traceback
-        else:
-            return inspect.getinnerframes(exc_traceback)
+
+        raise DeveloperException("Expected traceback type. Got '{}' instead.".format(type(exc_traceback)))
 
     def _is_stack_frame_type(self, exc_traceback):
         if type(exc_traceback) != self.INSPECT_STACK_BASE_TYPE:

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -184,7 +184,10 @@ class RaygunErrorMessage(object):
             for key in localVars:
                 try:
                     # Note that str() *can* fail; thus protect against it as much as we can.
-                    result[key] = str(localVars[key])
+                    if type(localVars[key]) is unicode:
+                        result[key] = localVars[key]
+                    else:
+                        result[key] = str(localVars[key])
                 except Exception as e:
                     try:
                         r = repr(localVars[key])

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -129,7 +129,7 @@ class RaygunMessage(object):
 
 class RaygunErrorMessage(object):
 
-    INSPECT_FRAME_TYPE_SIGNATURE = r'<frame [\w ]*0x\w*[>,]'
+    INSPECT_FRAME_TYPE_SIGNATURE = re.compile(r'<frame [\w ]*0x')
 
     def __init__(self, exc_type, exc_value, exc_traceback, options):
         self.className = exc_type.__name__
@@ -177,14 +177,15 @@ class RaygunErrorMessage(object):
         return self.className
 
     def _get_frames(self, exc_traceback):
-        if self._is_stack_frame_type(exc_traceback):
+        if type(exc_traceback) == list and self._is_stack_frame_type(exc_traceback):
             return exc_traceback
         else:
             return inspect.getinnerframes(exc_traceback)
 
     def _is_stack_frame_type(self, exc_traceback):
-        matches = re.findall(self.INSPECT_FRAME_TYPE_SIGNATURE, str(exc_traceback).lower())
-        return len(matches) >= 1
+        short_traceback = str(exc_traceback).lower()[0:100]
+        is_found = re.search(self.INSPECT_FRAME_TYPE_SIGNATURE, short_traceback)
+        return is_found
 
     def _get_locals(self, frame):
         result = {}

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -135,7 +135,7 @@ class RaygunErrorMessage(object):
 
         frames = None
         try:
-            if type(exc_traceback) == list and type(exc_traceback[0]) == tuple and str(exc_traceback[0][0].__class__) == "<type 'frame'>":
+            if type(exc_traceback) == list and type(exc_traceback[0]) == tuple and 'frame' in str(exc_traceback[0][0].__class__).lower():
                 frames = exc_traceback
             else:
                 frames = inspect.getinnerframes(exc_traceback)

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -135,6 +135,7 @@ class RaygunErrorMessage(object):
 
         frames = None
         try:
+
             if type(exc_traceback) == list and type(exc_traceback[0]) == tuple and 'frame' in str(exc_traceback[0][0].__class__).lower():
                 frames = exc_traceback
             else:

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -135,10 +135,7 @@ class RaygunErrorMessage(object):
 
         frames = None
         try:
-            if type(exc_traceback) == list and type(exc_traceback[0]) == tuple and 'frame' in str(type(exc_traceback[0][0])).lower():
-                frames = exc_traceback
-            else:
-                frames = inspect.getinnerframes(exc_traceback)
+            frames = self._get_frames(exc_traceback)
 
             if frames:
                 for frame in frames:
@@ -175,6 +172,15 @@ class RaygunErrorMessage(object):
 
     def get_classname(self):
         return self.className
+
+    def _get_frames(self, exc_traceback):
+        if self._is_stack(exc_traceback):
+            return exc_traceback
+        else:
+            return inspect.getinnerframes(exc_traceback)
+
+    def _is_stack(self, exc_traceback):
+        return type(exc_traceback) == list and type(exc_traceback[0]) == tuple and 'frame' in str(type(exc_traceback[0][0])).lower()
 
     def _get_locals(self, frame):
         result = {}

--- a/python2/tests/test_raygunmsgs.py
+++ b/python2/tests/test_raygunmsgs.py
@@ -165,6 +165,19 @@ class TestRaygunErrorMessage(unittest.TestCase):
 
         inspect.getinnerframes = originalGetinnerframes
 
+    def test_inspect_traceback_parameter(self):
+        should_include_me_too = "i'm local"
+        exception = ValueError("Hey there")
+
+        msg = raygunmsgs.RaygunErrorMessage(type(exception), exception, inspect.stack(), { 'transmitLocalVariables': True })
+        localVars = msg.__dict__['stackTrace'][0]['localVariables']
+
+        self.assertTrue('exception' in localVars)
+        self.assertEqual(exception.message, localVars['exception'])
+        self.assertTrue('should_include_me_too' in localVars)
+        self.assertEqual(should_include_me_too, localVars['should_include_me_too'])
+
+
 def getinnerframes_mock_methodname_none(exception):
     return [(
         'localVar',

--- a/python2/tests/test_raygunmsgs.py
+++ b/python2/tests/test_raygunmsgs.py
@@ -185,6 +185,15 @@ class TestRaygunErrorMessage(unittest.TestCase):
         fake_traceback = ["not real <frames>", "<frame fake>"]
         self.assertRaises(AttributeError, raygunmsgs.RaygunErrorMessage, type(exception), exception, fake_traceback, {'transmitLocalVariables': True})
 
+    def test_it_raises_DeveloperException_on_incorrect_stack(self):
+        exception = ValueError("")
+        incorrect_stack = inspect.stack()
+        frame_object = {'my object': 'error'}
+        klass = getattr(inspect, 'FrameInfo', tuple)
+        fake_frame_info = klass([frame_object, None, "", None])
+        incorrect_stack.append(fake_frame_info)
+        self.assertRaises(raygunmsgs.DeveloperException, raygunmsgs.RaygunErrorMessage, type(exception), exception, incorrect_stack, {'transmitLocalVariables': True})
+
 
 def getinnerframes_mock_methodname_none(exception):
     return [(

--- a/python2/tests/test_raygunmsgs.py
+++ b/python2/tests/test_raygunmsgs.py
@@ -140,16 +140,8 @@ class TestRaygunErrorMessage(unittest.TestCase):
             self.theException = e
             exc_info = sys.exc_info()
 
-            with mock.patch.object(raygunmsgs.RaygunErrorMessage, '_is_stack_frame_type') as _is_stack_frame_type:
-
-                # When given a traceback
-                self.assertTrue('traceback' in str(exc_info[2].__class__).lower())
-
-                self.msg = raygunmsgs.RaygunErrorMessage(exc_info[0], exc_info[1], exc_info[2], { 'transmitLocalVariables': True })
-
-                # It won't be checked with Regex to see if it's a <list> of <frames>.
-                # Thus a speedy result, with less overhead.
-                _is_stack_frame_type.assert_not_called()
+            self.assertTrue(inspect.istraceback(exc_info[2]))
+            self.msg = raygunmsgs.RaygunErrorMessage(exc_info[0], exc_info[1], exc_info[2], { 'transmitLocalVariables': True })
 
     def parent(self):
             raise TestRaygunErrorMessage.ParentError("Parent message")

--- a/python2/tests/test_raygunmsgs.py
+++ b/python2/tests/test_raygunmsgs.py
@@ -200,8 +200,9 @@ class TestRaygunErrorMessage(unittest.TestCase):
             fake_frame_info = klass(frame=fake_frame_object, filename='/tmp/specs/etc.py', lineno=666, function='<module>', code_context=None, index=None)
 
         incorrect_stack.append(fake_frame_info)
-        self.assertRaises(raygunmsgs.DeveloperException, raygunmsgs.RaygunErrorMessage, type(ValueError("")), ValueError(""), incorrect_stack, {'transmitLocalVariables': True})
 
+        with self.assertRaises(raygunmsgs.DeveloperException):
+            raygunmsgs.RaygunErrorMessage(type(ValueError("")), ValueError(""), incorrect_stack, {'transmitLocalVariables': True})
 
 
 def getinnerframes_mock_methodname_none(exception):

--- a/python2/tests/test_raygunmsgs.py
+++ b/python2/tests/test_raygunmsgs.py
@@ -186,13 +186,22 @@ class TestRaygunErrorMessage(unittest.TestCase):
         self.assertRaises(AttributeError, raygunmsgs.RaygunErrorMessage, type(exception), exception, fake_traceback, {'transmitLocalVariables': True})
 
     def test_it_raises_DeveloperException_on_incorrect_stack(self):
-        exception = ValueError("")
+        class frame(object):
+            def __init__(self):
+                pass
+
         incorrect_stack = inspect.stack()
-        frame_object = {'my object': 'error'}
+        fake_frame_object = frame()
         klass = getattr(inspect, 'FrameInfo', tuple)
-        fake_frame_info = klass([frame_object, None, "", None])
+
+        if klass == tuple:
+            fake_frame_info = klass([fake_frame_object, None, "", None])
+        else:
+            fake_frame_info = klass(frame=fake_frame_object, filename='/tmp/specs/etc.py', lineno=666, function='<module>', code_context=None, index=None)
+
         incorrect_stack.append(fake_frame_info)
-        self.assertRaises(raygunmsgs.DeveloperException, raygunmsgs.RaygunErrorMessage, type(exception), exception, incorrect_stack, {'transmitLocalVariables': True})
+        self.assertRaises(raygunmsgs.DeveloperException, raygunmsgs.RaygunErrorMessage, type(ValueError("")), ValueError(""), incorrect_stack, {'transmitLocalVariables': True})
+
 
 
 def getinnerframes_mock_methodname_none(exception):

--- a/python2/tests/test_raygunmsgs.py
+++ b/python2/tests/test_raygunmsgs.py
@@ -183,7 +183,9 @@ class TestRaygunErrorMessage(unittest.TestCase):
     def test_inspect_traceback_argument_failure(self):
         exception = ValueError("")
         fake_traceback = ["not real <frames>", "<frame fake>"]
-        self.assertRaises(AttributeError, raygunmsgs.RaygunErrorMessage, type(exception), exception, fake_traceback, {'transmitLocalVariables': True})
+
+        with self.assertRaises(raygunmsgs.DeveloperException):
+            raygunmsgs.RaygunErrorMessage(type(exception), exception, fake_traceback, {'transmitLocalVariables': True})
 
     def test_it_raises_DeveloperException_on_incorrect_stack(self):
         class frame(object):
@@ -203,6 +205,9 @@ class TestRaygunErrorMessage(unittest.TestCase):
 
         with self.assertRaises(raygunmsgs.DeveloperException):
             raygunmsgs.RaygunErrorMessage(type(ValueError("")), ValueError(""), incorrect_stack, {'transmitLocalVariables': True})
+
+        with self.assertRaises(raygunmsgs.DeveloperException):
+            raygunmsgs.RaygunErrorMessage(type(ValueError("")), ValueError(""), frame(), {'transmitLocalVariables': True})
 
 
 def getinnerframes_mock_methodname_none(exception):

--- a/python2/tests/test_raygunmsgs.py
+++ b/python2/tests/test_raygunmsgs.py
@@ -2,6 +2,7 @@ import sys
 import unittest2 as unittest
 import socket
 import inspect
+import mock
 
 from raygun4py import raygunmsgs
 
@@ -138,7 +139,17 @@ class TestRaygunErrorMessage(unittest.TestCase):
         except Exception as e:
             self.theException = e
             exc_info = sys.exc_info()
-            self.msg = raygunmsgs.RaygunErrorMessage(exc_info[0], exc_info[1], exc_info[2], { 'transmitLocalVariables': True })
+
+            with mock.patch.object(raygunmsgs.RaygunErrorMessage, '_is_stack_frame_type') as _is_stack_frame_type:
+
+                # When given a traceback
+                self.assertTrue('traceback' in str(exc_info[2].__class__).lower())
+
+                self.msg = raygunmsgs.RaygunErrorMessage(exc_info[0], exc_info[1], exc_info[2], { 'transmitLocalVariables': True })
+
+                # It won't be checked with Regex to see if it's a <list> of <frames>.
+                # Thus a speedy result, with less overhead.
+                _is_stack_frame_type.assert_not_called()
 
     def parent(self):
             raise TestRaygunErrorMessage.ParentError("Parent message")
@@ -176,6 +187,11 @@ class TestRaygunErrorMessage(unittest.TestCase):
         self.assertEqual(exception.message, localVars['exception'])
         self.assertTrue('should_include_me_too' in localVars)
         self.assertEqual(should_include_me_too, localVars['should_include_me_too'])
+
+    def test_inspect_traceback_argument_failure(self):
+        exception = ValueError("")
+        fake_traceback = ["not real <frames>", "<frame fake>"]
+        self.assertRaises(AttributeError, raygunmsgs.RaygunErrorMessage, type(exception), exception, fake_traceback, {'transmitLocalVariables': True})
 
 
 def getinnerframes_mock_methodname_none(exception):

--- a/python2/tests/test_raygunmsgs.py
+++ b/python2/tests/test_raygunmsgs.py
@@ -188,6 +188,8 @@ class TestRaygunErrorMessage(unittest.TestCase):
             raygunmsgs.RaygunErrorMessage(type(exception), exception, fake_traceback, {'transmitLocalVariables': True})
 
     def test_it_raises_DeveloperException_on_incorrect_stack(self):
+
+        # Try to mimic the original frame class objects, to try and spoof the system. (inspect.isframe() should return False)
         class frame(object):
             def __init__(self):
                 pass

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -130,7 +130,7 @@ class RaygunMessage(object):
 
 class RaygunErrorMessage(object):
 
-    INSPECT_FRAME_TYPE_SIGNATURE = r'<frame [\w ]*0x\w*[>,]'
+    INSPECT_FRAME_TYPE_SIGNATURE = re.compile(r'<frame [\w ]*0x')
 
     def __init__(self, exc_type, exc_value, exc_traceback, options):
         self.className = exc_type.__name__
@@ -189,14 +189,15 @@ class RaygunErrorMessage(object):
         return self.className
 
     def _get_frames(self, exc_traceback):
-        if self._is_stack_frame_type(exc_traceback):
+        if type(exc_traceback) == list and self._is_stack_frame_type(exc_traceback):
             return exc_traceback
         else:
             return inspect.getinnerframes(exc_traceback)
 
     def _is_stack_frame_type(self, exc_traceback):
-        matches = re.findall(self.INSPECT_FRAME_TYPE_SIGNATURE, str(exc_traceback).lower())
-        return len(matches) >= 1
+        short_traceback = str(exc_traceback).lower()[0:100]
+        is_found = re.search(self.INSPECT_FRAME_TYPE_SIGNATURE, short_traceback)
+        return is_found
 
     def _get_locals(self, frame):
         result = {}

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -135,7 +135,7 @@ class RaygunErrorMessage(object):
         self.stackTrace = []
 
         try:
-            if type(exc_traceback) == list and type(exc_traceback[0]) == inspect.FrameInfo:
+            if type(exc_traceback) == list and 'frame' in str(type(exc_traceback[0])).lower():
                 frames = exc_traceback
             else:
                 frames = inspect.getinnerframes(exc_traceback)

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -196,7 +196,8 @@ class RaygunErrorMessage(object):
             return inspect.getinnerframes(exc_traceback)
 
     def _is_stack_frame_type(self, exc_traceback):
-        # Should we have to search through a string, "<frame" should be found within the first 50 characters.
+        # Try not to search through entire string, (which could be an entire stack trace) by truncating to 100.
+        # "<frame" should be found within the first 50 characters.
         # Example:
         # >>> str(inspect.stack()).lower()[0:50]
         #     "[frameinfo(frame=<frame at 0x1074b8528, file '<std"

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -137,6 +137,7 @@ class RaygunErrorMessage(object):
         self.message = "%s: %s" % (exc_type.__name__, exc_value)
         self.stackTrace = []
 
+        frames = None
         try:
             frames = self._get_frames(exc_traceback)
 

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -135,7 +135,11 @@ class RaygunErrorMessage(object):
         self.stackTrace = []
 
         try:
-            frames = inspect.getinnerframes(exc_traceback)
+            if type(exc_traceback) == list and type(exc_traceback[0]) == inspect.FrameInfo:
+                frames = exc_traceback
+            else:
+                frames = inspect.getinnerframes(exc_traceback)
+
 
             if frames:
                 for frame in frames:
@@ -193,7 +197,10 @@ class RaygunErrorMessage(object):
             for key in localVars:
                 try:
                     # Note that str() *can* fail; thus protect against it as much as we can.
-                    result[key] = str(localVars[key])
+                    if type(localVars[key]) is unicode:
+                        result[key] = localVars[key]
+                    else:
+                        result[key] = str(localVars[key])
                 except Exception as e:
                     try:
                         r = repr(localVars[key])

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -194,10 +194,13 @@ class RaygunErrorMessage(object):
         return self.className
 
     def _get_frames(self, exc_traceback):
+        if not exc_traceback or inspect.istraceback(exc_traceback):
+            return inspect.getinnerframes(exc_traceback)
+
         if self._is_stack_frame_type(exc_traceback):
             return exc_traceback
-        else:
-            return inspect.getinnerframes(exc_traceback)
+
+        raise DeveloperException("Expected traceback type. Got '{}' instead.".format(type(exc_traceback)))
 
     def _is_stack_frame_type(self, exc_traceback):
         if type(exc_traceback) != self.INSPECT_STACK_BASE_TYPE:

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -195,11 +195,8 @@ class RaygunErrorMessage(object):
             return inspect.getinnerframes(exc_traceback)
 
     def _is_stack_frame_type(self, exc_traceback):
-        try:
-            matches = re.findall(INSPECT_FRAME_TYPE_REGEX, str(exc_traceback).lower())
-            return len(matches) > 1
-        except Exception as e:
-            return False
+        matches = re.findall(self.INSPECT_FRAME_TYPE_SIGNATURE, str(exc_traceback).lower())
+        return len(matches) >= 1
 
     def _get_locals(self, frame):
         result = {}

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -15,6 +15,10 @@ from datetime import datetime
 from raygun4py import http_utilities
 
 
+class DeveloperException(Exception):
+    pass
+
+
 class RaygunMessageBuilder(object):
 
     def __init__(self, options):
@@ -204,7 +208,7 @@ class RaygunErrorMessage(object):
                 return False
             else:
                 if not inspect.isframe(frame[0]):
-                    return False
+                    raise DeveloperException("Expected frame type. Got '{}' instead.".format(type(frame[0])))
 
         return True
 

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -140,7 +140,6 @@ class RaygunErrorMessage(object):
             else:
                 frames = inspect.getinnerframes(exc_traceback)
 
-
             if frames:
                 for frame in frames:
                     localVariables = None

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -135,10 +135,9 @@ class RaygunErrorMessage(object):
         self.stackTrace = []
 
         try:
-            if type(exc_traceback) == list:
-                print(type(exc_traceback[0]))
-
-            if type(exc_traceback) == list and type(exc_traceback[0]) == inspect.FrameInfo:
+            if type(exc_traceback) == list and type(exc_traceback[0]) == tuple and 'frame' in str(type(exc_traceback[0][0])).lower():
+                frames = exc_traceback
+            elif type(exc_traceback) == list and 'frame' in str(type(exc_traceback[0])).lower():
                 frames = exc_traceback
             else:
                 frames = inspect.getinnerframes(exc_traceback)

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -135,12 +135,7 @@ class RaygunErrorMessage(object):
         self.stackTrace = []
 
         try:
-            if type(exc_traceback) == list and type(exc_traceback[0]) == tuple and 'frame' in str(type(exc_traceback[0][0])).lower():
-                frames = exc_traceback
-            elif type(exc_traceback) == list and 'frame' in str(type(exc_traceback[0])).lower():
-                frames = exc_traceback
-            else:
-                frames = inspect.getinnerframes(exc_traceback)
+            frames = self._get_frames(exc_traceback)
 
             if frames:
                 for frame in frames:
@@ -189,6 +184,21 @@ class RaygunErrorMessage(object):
 
     def get_classname(self):
         return self.className
+
+    def _get_frames(self, exc_traceback):
+        if self._is_stack(exc_traceback):
+            return exc_traceback
+        else:
+            return inspect.getinnerframes(exc_traceback)
+
+    def _is_stack(self, exc_traceback):
+        if type(exc_traceback) == list:
+            if type(exc_traceback[0]) == tuple and 'frame' in str(type(exc_traceback[0][0])).lower():
+                return True
+            elif 'frame' in str(type(exc_traceback[0])).lower():
+                return True
+        else:
+            return False
 
     def _get_locals(self, frame):
         result = {}

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -1,6 +1,5 @@
 import sys
 import os
-import re
 import inspect
 import jsonpickle
 from raygun4py import __version__
@@ -130,7 +129,8 @@ class RaygunMessage(object):
 
 class RaygunErrorMessage(object):
 
-    INSPECT_FRAME_TYPE_SIGNATURE = re.compile(r'<frame [\w ]*0x')
+    INSPECT_STACK_BASE_TYPE = list
+    INSPECT_STACK_CLASS_SUBTYPE = inspect.FrameInfo
 
     def __init__(self, exc_type, exc_value, exc_traceback, options):
         self.className = exc_type.__name__
@@ -190,21 +190,23 @@ class RaygunErrorMessage(object):
         return self.className
 
     def _get_frames(self, exc_traceback):
-        if type(exc_traceback) == list and self._is_stack_frame_type(exc_traceback):
+        if self._is_stack_frame_type(exc_traceback):
             return exc_traceback
         else:
             return inspect.getinnerframes(exc_traceback)
 
     def _is_stack_frame_type(self, exc_traceback):
-        # Try not to search through entire string, (which could be an entire stack trace) by truncating to 100.
-        # "<frame" should be found within the first 50 characters.
-        # Example:
-        # >>> str(inspect.stack()).lower()[0:50]
-        #     "[frameinfo(frame=<frame at 0x1074b8528, file '<std"
-        #
-        short_traceback = str(exc_traceback).lower()[0:100]
-        is_found = re.search(self.INSPECT_FRAME_TYPE_SIGNATURE, short_traceback)
-        return is_found
+        if type(exc_traceback) != self.INSPECT_STACK_BASE_TYPE:
+            return False
+
+        for frame in exc_traceback:
+            if type(frame) != self.INSPECT_STACK_CLASS_SUBTYPE:
+                return False
+            else:
+                if not inspect.isframe(frame[0]):
+                    return False
+
+        return True
 
     def _get_locals(self, frame):
         result = {}

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import re
 import inspect
 import jsonpickle
 from raygun4py import __version__
@@ -129,6 +130,8 @@ class RaygunMessage(object):
 
 class RaygunErrorMessage(object):
 
+    INSPECT_FRAME_TYPE_SIGNATURE = r'<frame [\w ]*0x\w*[>,]'
+
     def __init__(self, exc_type, exc_value, exc_traceback, options):
         self.className = exc_type.__name__
         self.message = "%s: %s" % (exc_type.__name__, exc_value)
@@ -186,18 +189,16 @@ class RaygunErrorMessage(object):
         return self.className
 
     def _get_frames(self, exc_traceback):
-        if self._is_stack(exc_traceback):
+        if self._is_stack_frame_type(exc_traceback):
             return exc_traceback
         else:
             return inspect.getinnerframes(exc_traceback)
 
-    def _is_stack(self, exc_traceback):
-        if type(exc_traceback) == list:
-            if type(exc_traceback[0]) == tuple and 'frame' in str(type(exc_traceback[0][0])).lower():
-                return True
-            elif 'frame' in str(type(exc_traceback[0])).lower():
-                return True
-        else:
+    def _is_stack_frame_type(self, exc_traceback):
+        try:
+            matches = re.findall(INSPECT_FRAME_TYPE_REGEX, str(exc_traceback).lower())
+            return len(matches) > 1
+        except Exception as e:
             return False
 
     def _get_locals(self, frame):

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -130,7 +130,7 @@ class RaygunMessage(object):
 class RaygunErrorMessage(object):
 
     INSPECT_STACK_BASE_TYPE = list
-    INSPECT_STACK_CLASS_SUBTYPE = inspect.FrameInfo
+    INSPECT_STACK_CLASS_SUBTYPE = getattr(inspect, 'FrameInfo', tuple)
 
     def __init__(self, exc_type, exc_value, exc_traceback, options):
         self.className = exc_type.__name__

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -135,7 +135,10 @@ class RaygunErrorMessage(object):
         self.stackTrace = []
 
         try:
-            if type(exc_traceback) == list and 'frame' in str(type(exc_traceback[0])).lower():
+            if type(exc_traceback) == list:
+                print(type(exc_traceback[0]))
+
+            if type(exc_traceback) == list and type(exc_traceback[0]) == inspect.FrameInfo:
                 frames = exc_traceback
             else:
                 frames = inspect.getinnerframes(exc_traceback)

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -197,10 +197,7 @@ class RaygunErrorMessage(object):
             for key in localVars:
                 try:
                     # Note that str() *can* fail; thus protect against it as much as we can.
-                    if type(localVars[key]) is unicode:
-                        result[key] = localVars[key]
-                    else:
-                        result[key] = str(localVars[key])
+                    result[key] = str(localVars[key])
                 except Exception as e:
                     try:
                         r = repr(localVars[key])

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -196,6 +196,11 @@ class RaygunErrorMessage(object):
             return inspect.getinnerframes(exc_traceback)
 
     def _is_stack_frame_type(self, exc_traceback):
+        # Should we have to search through a string, "<frame" should be found within the first 50 characters.
+        # Example:
+        # >>> str(inspect.stack()).lower()[0:50]
+        #     "[frameinfo(frame=<frame at 0x1074b8528, file '<std"
+        #
         short_traceback = str(exc_traceback).lower()[0:100]
         is_found = re.search(self.INSPECT_FRAME_TYPE_SIGNATURE, short_traceback)
         return is_found

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -236,6 +236,23 @@ class TestRaygunErrorMessage(unittest.TestCase):
         incorrect_stack.append(fake_frame_info)
         self.assertRaises(raygunmsgs.DeveloperException, raygunmsgs.RaygunErrorMessage, type(ValueError("")), ValueError(""), incorrect_stack, {'transmitLocalVariables': True})
 
+    def test_it_raises_DeveloperException_on_incorrect_stack_999(self):
+        class frame(object):
+            def __init__(self):
+                pass
+
+        incorrect_stack = inspect.stack()
+        fake_frame_object = frame()
+        klass = getattr(inspect, 'FrameInfo', tuple)
+
+        if type(klass) == tuple:
+            fake_frame_info = klass([fake_frame_object, None, "", None])
+        else:
+            fake_frame_info = klass(frame=fake_frame_object, filename='/tmp/specs/etc.py', lineno=666, function='<module>', code_context=None, index=None)
+
+        incorrect_stack.append(fake_frame_info)
+        self.assertRaises(raygunmsgs.DeveloperException, raygunmsgs.RaygunErrorMessage, type(ValueError("")), ValueError(""), incorrect_stack, {'transmitLocalVariables': True})
+
 
 def getinnerframes_mock_methodname_none(exception):
     return [(

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -221,7 +221,9 @@ class TestRaygunErrorMessage(unittest.TestCase):
     def test_inspect_traceback_argument_failure(self):
         exception = ValueError("")
         fake_traceback = ["not real <frames>", "<frame fake>"]
-        self.assertRaises(AttributeError, raygunmsgs.RaygunErrorMessage, type(exception), exception, fake_traceback, {'transmitLocalVariables': True})
+
+        with self.assertRaises(raygunmsgs.DeveloperException):
+            raygunmsgs.RaygunErrorMessage(type(exception), exception, fake_traceback, {'transmitLocalVariables': True})
 
     def test_it_raises_DeveloperException_on_incorrect_stack(self):
         class frame(object):
@@ -241,6 +243,9 @@ class TestRaygunErrorMessage(unittest.TestCase):
 
         with self.assertRaises(raygunmsgs.DeveloperException):
             raygunmsgs.RaygunErrorMessage(type(ValueError("")), ValueError(""), incorrect_stack, {'transmitLocalVariables': True})
+
+        with self.assertRaises(raygunmsgs.DeveloperException):
+            raygunmsgs.RaygunErrorMessage(type(ValueError("")), ValueError(""), frame(), {'transmitLocalVariables': True})
 
 
 def getinnerframes_mock_methodname_none(exception):

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -224,13 +224,17 @@ class TestRaygunErrorMessage(unittest.TestCase):
         self.assertRaises(AttributeError, raygunmsgs.RaygunErrorMessage, type(exception), exception, fake_traceback, {'transmitLocalVariables': True})
 
     def test_it_raises_DeveloperException_on_incorrect_stack(self):
-        exception = ValueError("")
         incorrect_stack = inspect.stack()
-        frame_object = {'my object': 'error'}
+        fake_frame_object = {'my object': 'error'}
         klass = getattr(inspect, 'FrameInfo', tuple)
-        fake_frame_info = klass([frame_object, None, "", None])
+
+        if type(klass) == tuple:
+            fake_frame_info = klass([fake_frame_object, None, "", None])
+        else:
+            fake_frame_info = klass(filename='/tmp/specs/etc.py', lineno=666, function='def abc', code_context='idk', index=0)
+
         incorrect_stack.append(fake_frame_info)
-        self.assertRaises(raygunmsgs.DeveloperException, raygunmsgs.RaygunErrorMessage, type(exception), exception, incorrect_stack, {'transmitLocalVariables': True})
+        self.assertRaises(raygunmsgs.DeveloperException, raygunmsgs.RaygunErrorMessage, type(ValueError("")), ValueError(""), incorrect_stack, {'transmitLocalVariables': True})
 
 
 def getinnerframes_mock_methodname_none(exception):

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -238,7 +238,9 @@ class TestRaygunErrorMessage(unittest.TestCase):
             fake_frame_info = klass(frame=fake_frame_object, filename='/tmp/specs/etc.py', lineno=666, function='<module>', code_context=None, index=None)
 
         incorrect_stack.append(fake_frame_info)
-        self.assertRaises(raygunmsgs.DeveloperException, raygunmsgs.RaygunErrorMessage, type(ValueError("")), ValueError(""), incorrect_stack, {'transmitLocalVariables': True})
+
+        with self.assertRaises(raygunmsgs.DeveloperException):
+            raygunmsgs.RaygunErrorMessage(type(ValueError("")), ValueError(""), incorrect_stack, {'transmitLocalVariables': True})
 
 
 def getinnerframes_mock_methodname_none(exception):

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -147,19 +147,10 @@ class TestRaygunErrorMessage(unittest.TestCase):
             self.parent()
         except Exception as e:
             self.theException = e
-
             exc_info = sys.exc_info()
 
-            with mock.patch.object(raygunmsgs.RaygunErrorMessage, '_is_stack_frame_type') as _is_stack_frame_type:
-
-                # When given a traceback
-                self.assertTrue('traceback' in str(exc_info[2].__class__).lower())
-
-                self.msg = raygunmsgs.RaygunErrorMessage(exc_info[0], exc_info[1], exc_info[2], { 'transmitLocalVariables': True })
-
-                # It won't be checked with Regex to see if it's a <list> of <frames>.
-                # Thus a speedy result, with less overhead.
-                _is_stack_frame_type.assert_not_called()
+            self.assertTrue(inspect.istraceback(exc_info[2]))
+            self.msg = raygunmsgs.RaygunErrorMessage(exc_info[0], exc_info[1], exc_info[2], { 'transmitLocalVariables': True })
 
     def parent(self):
             try:

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -223,6 +223,15 @@ class TestRaygunErrorMessage(unittest.TestCase):
         fake_traceback = ["not real <frames>", "<frame fake>"]
         self.assertRaises(AttributeError, raygunmsgs.RaygunErrorMessage, type(exception), exception, fake_traceback, {'transmitLocalVariables': True})
 
+    def test_it_raises_DeveloperException_on_incorrect_stack(self):
+        exception = ValueError("")
+        incorrect_stack = inspect.stack()
+        frame_object = {'my object': 'error'}
+        klass = getattr(inspect, 'FrameInfo', tuple)
+        fake_frame_info = klass([frame_object, None, "", None])
+        incorrect_stack.append(fake_frame_info)
+        self.assertRaises(raygunmsgs.DeveloperException, raygunmsgs.RaygunErrorMessage, type(exception), exception, incorrect_stack, {'transmitLocalVariables': True})
+
 
 def getinnerframes_mock_methodname_none(exception):
     return [(

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -226,6 +226,8 @@ class TestRaygunErrorMessage(unittest.TestCase):
             raygunmsgs.RaygunErrorMessage(type(exception), exception, fake_traceback, {'transmitLocalVariables': True})
 
     def test_it_raises_DeveloperException_on_incorrect_stack(self):
+
+        # Try to mimic the original frame class objects, to try and spoof the system. (inspect.isframe() should return False)
         class frame(object):
             def __init__(self):
                 pass

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -209,7 +209,7 @@ class TestRaygunErrorMessage(unittest.TestCase):
         localVars = msg.__dict__['stackTrace'][0]['localVariables']
 
         self.assertTrue('exception' in localVars)
-        self.assertEqual(exception.message, localVars['exception'])
+        self.assertEqual(str(exception), localVars['exception'])
         self.assertTrue('should_include_me_too' in localVars)
         self.assertEqual(should_include_me_too, localVars['should_include_me_too'])
 

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -201,6 +201,19 @@ class TestRaygunErrorMessage(unittest.TestCase):
 
         inspect.getinnerframes = original_getinnerframes
 
+    def test_inspect_traceback_parameter(self):
+        should_include_me_too = "i'm local"
+        exception = ValueError("Hey there")
+
+        msg = raygunmsgs.RaygunErrorMessage(type(exception), exception, inspect.stack(), { 'transmitLocalVariables': True })
+        localVars = msg.__dict__['stackTrace'][0]['localVariables']
+
+        self.assertTrue('exception' in localVars)
+        self.assertEqual(exception.message, localVars['exception'])
+        self.assertTrue('should_include_me_too' in localVars)
+        self.assertEqual(should_include_me_too, localVars['should_include_me_too'])
+
+
 def getinnerframes_mock_methodname_none(exception):
     return [(
         'localVar',

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -224,19 +224,6 @@ class TestRaygunErrorMessage(unittest.TestCase):
         self.assertRaises(AttributeError, raygunmsgs.RaygunErrorMessage, type(exception), exception, fake_traceback, {'transmitLocalVariables': True})
 
     def test_it_raises_DeveloperException_on_incorrect_stack(self):
-        incorrect_stack = inspect.stack()
-        fake_frame_object = {'my object': 'error'}
-        klass = getattr(inspect, 'FrameInfo', tuple)
-
-        if type(klass) == tuple:
-            fake_frame_info = klass([fake_frame_object, None, "", None])
-        else:
-            fake_frame_info = klass(filename='/tmp/specs/etc.py', lineno=666, function='def abc', code_context='idk', index=0)
-
-        incorrect_stack.append(fake_frame_info)
-        self.assertRaises(raygunmsgs.DeveloperException, raygunmsgs.RaygunErrorMessage, type(ValueError("")), ValueError(""), incorrect_stack, {'transmitLocalVariables': True})
-
-    def test_it_raises_DeveloperException_on_incorrect_stack_999(self):
         class frame(object):
             def __init__(self):
                 pass
@@ -245,7 +232,7 @@ class TestRaygunErrorMessage(unittest.TestCase):
         fake_frame_object = frame()
         klass = getattr(inspect, 'FrameInfo', tuple)
 
-        if type(klass) == tuple:
+        if klass == tuple:
             fake_frame_info = klass([fake_frame_object, None, "", None])
         else:
             fake_frame_info = klass(frame=fake_frame_object, filename='/tmp/specs/etc.py', lineno=666, function='<module>', code_context=None, index=None)


### PR DESCRIPTION
As a developer, I want to be able to send my traceback to raygun using something other than a python `traceback` and be able to use something like `inspect.stack()` instead. 

TODO:
- [x] Feature for Python2
- [x] Feature for Python3
- [x] Test coverage