### PR TITLE
fix: Updated middleware Providers to take Sender config, fixed wsgi CONTENT_LENGTH error

### DIFF
--- a/python2/raygun4py/middleware/flask.py
+++ b/python2/raygun4py/middleware/flask.py
@@ -11,9 +11,10 @@ log = logging.getLogger(__name__)
 
 
 class Provider(object):
-    def __init__(self, flaskApp, apiKey):
+    def __init__(self, flaskApp, apiKey, config=None):
         self.flaskApp = flaskApp
         self.apiKey = apiKey
+        self.config = config
         self.sender = None
 
         got_request_exception.connect(self.send_exception, sender=flaskApp)
@@ -24,7 +25,7 @@ class Provider(object):
         if not hasattr(self.flaskApp, 'extensions'):
             self.flaskApp.extensions = {}
 
-        self.sender = raygunprovider.RaygunSender(self.apiKey)
+        self.sender = raygunprovider.RaygunSender(self.apiKey, config=self.config)
         return self.sender
 
     def send_exception(self, *args, **kwargs):

--- a/python2/raygun4py/middleware/wsgi.py
+++ b/python2/raygun4py/middleware/wsgi.py
@@ -8,9 +8,9 @@ log = logging.getLogger(__name__)
 
 class Provider(object):
 
-    def __init__(self, app, apiKey):
+    def __init__(self, app, apiKey, config=None):
         self.app = app
-        self.sender = raygunprovider.RaygunSender(apiKey)
+        self.sender = raygunprovider.RaygunSender(apiKey, config=config)
 
     def __call__(self, environ, start_response):
         if not self.sender:

--- a/python3/raygun4py/middleware/flask.py
+++ b/python3/raygun4py/middleware/flask.py
@@ -7,9 +7,10 @@ log = logging.getLogger(__name__)
 
 
 class Provider(object):
-    def __init__(self, flaskApp, apiKey):
+    def __init__(self, flaskApp, apiKey, config=None):
         self.flaskApp = flaskApp
         self.apiKey = apiKey
+        self.config = config
         self.sender = None
 
         got_request_exception.connect(self.send_exception, sender=flaskApp)
@@ -20,7 +21,7 @@ class Provider(object):
         if not hasattr(self.flaskApp, 'extensions'):
             self.flaskApp.extensions = {}
 
-        self.sender = raygunprovider.RaygunSender(self.apiKey)
+        self.sender = raygunprovider.RaygunSender(self.apiKey, config=self.config)
         return self.sender
 
     def send_exception(self, *args, **kwargs):

--- a/python3/raygun4py/middleware/wsgi.py
+++ b/python3/raygun4py/middleware/wsgi.py
@@ -8,9 +8,9 @@ log = logging.getLogger(__name__)
 
 class Provider(object):
 
-    def __init__(self, app, apiKey):
+    def __init__(self, app, apiKey, config=None):
         self.app = app
-        self.sender = raygunprovider.RaygunSender(apiKey)
+        self.sender = raygunprovider.RaygunSender(apiKey, config=config)
 
     def __call__(self, environ, start_response):
         if not self.sender:


### PR DESCRIPTION
I'm using raygun4py in a project where it's already used as wsgi middleware. Recently we found that some of the env vars going through to Raygun we wanted to filter out, and it seems the way to do that is via config to the RaygunSender when initialising it.

Unfortunately, only the Django middleware supports this, so I raised this PR to hopefully get the other middlewares up to the same level.