### PR TITLE
[Customers Product]: Change references from 'Users' to 'Customers' within documentation 👥 

### DIFF
--- a/CHANGELOG.old.rst
+++ b/CHANGELOG.old.rst
@@ -99,7 +99,7 @@
 
 1.1.0
 
-- Added set_user function for unique user tracking; internal refactor to make module more pythonic
+- Added set_user function for user tracking/Customers; internal refactor to make module more pythonic
 
 1.0.0
 

--- a/README.rst
+++ b/README.rst
@@ -310,7 +310,7 @@ Call this to attach a SemVer version to each message that is sent. This will be 
 | set_user       | user_info     | Dict               |
 +----------------+---------------+--------------------+
 
-User data can be passed in which will be displayed in the Raygun web app. The dict you pass in should look this this:
+Customer data can be passed in which will be displayed in the Raygun web app. The dict you pass in should look this this:
 
 .. code:: python
 
@@ -322,7 +322,7 @@ User data can be passed in which will be displayed in the Raygun web app. The di
       'identifier': 'foo@bar.com'
     })
 
-`identifier` should be whatever unique key you use to identify users, for instance an email address. This will be used to create the count of unique affected users. If you wish to anonymize it, you can generate and store a UUID or hash one or more of their unique login data fields, if available.
+`identifier` should be whatever unique key you use to identify customers, for instance an email address. This will be used to create the count of affected customers. If you wish to anonymize it, you can generate and store a UUID or hash one or more of their unique login data fields, if available.
 
 Custom grouping logic
 ---------------------


### PR DESCRIPTION
## [Customers Product]: Change references from 'User tracking' to 'Customers' within documentation 👤

**NOTE: This is not to be merged until we have fully released the name change in the Raygun application. Changes to 'users' within the code need to be discussed and planned for.**

### Description 📝 
This PR is to updating the name convention for 'User tracking' to now be 'Customers' to reflect what's within the Raygun application.

**Updates**
👉 Update `README` documentation
👉 Update `CHANGELOG` document

### Test plan 🧪 
- Make sure documentation changes are reflected to be 'Customers' instead of 'Users' or 'User tracking' (except for within change log for future reference)

### Checklist ✔️ 
- [ ] Builds pass
- [ ] Reviewed by another developer
- [ ] Code is written to standards