### PR TITLE
fix: Update filter_keys wildcard behaviour to work closer to expectations

### DIFF
--- a/python2/raygun4py/utilities.py
+++ b/python2/raygun4py/utilities.py
@@ -24,8 +24,7 @@ def filter_keys(filtered_keys, object):
                     iteration_target[key] = '<filtered>'
                 elif '*' in filter_key:
                     sanitised_key = filter_key.replace('*', '')
-
-                    if sanitised_key in key:
+                    if key.startswith(sanitised_key):
                         iteration_target[key] = '<filtered>'
 
 

--- a/python2/tests/test_utilities.py
+++ b/python2/tests/test_utilities.py
@@ -30,12 +30,12 @@ class TestRaygunUtilities(unittest.TestCase):
         self.assertEqual(test_obj['foo'], '<filtered>')
         self.assertEqual(test_obj['boo']['foo'], '<filtered>')
 
-
     def test_filter_keys_with_wildcard(self):
         test_obj = {
             'foobr': 'bar',
             'foobz': 'baz',
             'fooqx': 'foo',
+            'afooqx': 'afoo',
             'baz': 'qux'
         }
 
@@ -44,6 +44,8 @@ class TestRaygunUtilities(unittest.TestCase):
         self.assertEqual(test_obj['foobr'], '<filtered>')
         self.assertEqual(test_obj['foobz'], '<filtered>')
         self.assertEqual(test_obj['fooqx'], '<filtered>')
+        self.assertEqual(test_obj['afooqx'], 'afoo')
+        self.assertEqual(test_obj['baz'], 'qux')
 
 def main():
     unittest.main()

--- a/python3/raygun4py/utilities.py
+++ b/python3/raygun4py/utilities.py
@@ -24,8 +24,7 @@ def filter_keys(filtered_keys, object):
                     iteration_target[key] = '<filtered>'
                 elif '*' in filter_key:
                     sanitised_key = filter_key.replace('*', '')
-
-                    if sanitised_key in key:
+                    if key.startswith(sanitised_key):
                         iteration_target[key] = '<filtered>'
 
 

--- a/python3/tests/test_utilities.py
+++ b/python3/tests/test_utilities.py
@@ -29,12 +29,12 @@ class TestRaygunUtilities(unittest.TestCase):
         self.assertEqual(test_obj['foo'], '<filtered>')
         self.assertEqual(test_obj['boo']['foo'], '<filtered>')
 
-
     def test_filter_keys_with_wildcard(self):
         test_obj = {
             'foobr': 'bar',
             'foobz': 'baz',
             'fooqx': 'foo',
+            'afooqx': 'afoo',
             'baz': 'qux'
         }
 
@@ -43,6 +43,8 @@ class TestRaygunUtilities(unittest.TestCase):
         self.assertEqual(test_obj['foobr'], '<filtered>')
         self.assertEqual(test_obj['foobz'], '<filtered>')
         self.assertEqual(test_obj['fooqx'], '<filtered>')
+        self.assertEqual(test_obj['afooqx'], 'afoo')
+        self.assertEqual(test_obj['baz'], 'qux')
 
 def main():
     unittest.main()


### PR DESCRIPTION
Hey - I just noticed this when I was checking out the library. The current behaviour for filtering of `AWS*` will filter on any string that contains `AWS` rather than any string that starts with `AWS`. I think this is contrary to what most people will expect.

Of course - maybe people are relying on the current behaviour, so maybe you want a documentation change instead to make the current behaviour clearer. Or a config option defaulting how wildcard behaviour is expected to work.

Cross checking against raygun4net and it seems like the python library is lacking a bit of flexibility, the .net library supports `startswith*`, `endswith*` and `*contains*` with what you would expect.