### PR TITLE
Resolve crash reports not logging post requests in Django

### DIFF
--- a/python2/tests/middleware/test_django.py
+++ b/python2/tests/middleware/test_django.py
@@ -14,12 +14,19 @@ class DjangoProviderTests(SimpleTestCase):
     def setUp(self):
         request_factory = RequestFactory()
         self.get_request = request_factory.get('/foo')
+        self.post_request = request_factory.post('/foo')
 
-    def test_map_request(self):
+    def test_get_map_request(self):
         provider = Provider()
         request_payload = provider._mapRequest(self.get_request)
         self.assertEqual(request_payload['url'], '/foo')
         self.assertEqual(request_payload['httpMethod'], 'GET')
+
+    def test_post_map_request(self):
+        provider = Provider()
+        request_payload = provider._mapRequest(self.post_request)
+        self.assertEqual(request_payload['url'], '/foo')
+        self.assertEqual(request_payload['httpMethod'], 'POST')
 
     def test_get_django_environment(self):
         provider = Provider()

--- a/python3/raygun4py/middleware/django.py
+++ b/python3/raygun4py/middleware/django.py
@@ -38,7 +38,7 @@ class Provider(MiddlewareMixin):
             'queryString': dict((key, request.GET[key]) for key in request.GET),
             'form': dict((key, request.POST[key]) for key in request.POST),
             'headers': _headers,
-            'rawData': request.body if hasattr(request, 'body') else getattr(request, 'raw_post_data', {})
+            'rawData': request.data if hasattr(request, 'data') else getattr(request, 'raw_post_data', {})
         }
 
     def _get_django_environment(self):

--- a/python3/tests/middleware/test_django.py
+++ b/python3/tests/middleware/test_django.py
@@ -14,12 +14,19 @@ class DjangoProviderTests(SimpleTestCase):
     def setUp(self):
         request_factory = RequestFactory()
         self.get_request = request_factory.get('/foo')
+        self.post_request = request_factory.post('/foo')
 
-    def test_map_request(self):
+    def test_get_map_request(self):
         provider = Provider()
         request_payload = provider._mapRequest(self.get_request)
         self.assertEqual(request_payload['url'], '/foo')
         self.assertEqual(request_payload['httpMethod'], 'GET')
+
+    def test_post_map_request(self):
+        provider = Provider()
+        request_payload = provider._mapRequest(self.post_request)
+        self.assertEqual(request_payload['url'], '/foo')
+        self.assertEqual(request_payload['httpMethod'], 'POST')
 
     def test_get_django_environment(self):
         provider = Provider()


### PR DESCRIPTION
Related GH issue: https://github.com/MindscapeHQ/raygun4py/issues/93

This issue is not present in python2.7