### PR TITLE
Add optional user_override attribute to send_exception

### DIFF
--- a/python2/raygun4py/raygunprovider.py
+++ b/python2/raygun4py/raygunprovider.py
@@ -81,7 +81,7 @@ class RaygunSender:
         if callable(callback):
             self.grouping_key_callback = callback
 
-    def send_exception(self, exception=None, exc_info=None, **kwargs):
+    def send_exception(self, exception=None, exc_info=None, user_override=None, **kwargs):
         options = {
             'transmitLocalVariables': self.transmit_local_variables,
             'transmitGlobalVariables': self.transmit_global_variables
@@ -123,7 +123,7 @@ class RaygunSender:
 
         return tags, custom_data, http_request, extra_environment_data
 
-    def _create_message(self, raygunExceptionMessage, tags, user_custom_data, http_request, extra_environment_data):
+    def _create_message(self, raygunExceptionMessage, tags, user_custom_data, http_request, extra_environment_data, user_override=None):
         options = {
             'transmit_environment_variables': self.transmit_environment_variables
         }
@@ -137,7 +137,7 @@ class RaygunSender:
             .set_tags(tags) \
             .set_customdata(user_custom_data) \
             .set_request_details(http_request) \
-            .set_user(self.user) \
+            .set_user(user_override if user_override else self.user) \
             .build()
 
     def _transform_message(self, message):

--- a/python2/tests/test_functional.py
+++ b/python2/tests/test_functional.py
@@ -26,6 +26,29 @@ class TestRaygun4PyFunctional(unittest.TestCase):
 
             self.assertEqual(httpResult[0], 202)
 
+    def test_send_with_user_override(self):
+        client = raygunprovider.RaygunSender(self.apiKey)
+        client.set_user({
+            'firstName': 'baz',
+            'fullName': 'baz bar',
+            'email': 'baz@bar.com',
+            'isAnonymous': False,
+            'identifier': 'baz@bar.com'
+          })
+
+        try:
+            raise Exception("Raygun4py manual sending test - user override")
+        except:
+            httpResult = client.send_exception(exc_info=sys.exc_info(), user_override={
+                'firstName': 'foo',
+                'fullName': 'foo bar',
+                'email': 'foo@bar.com',
+                'isAnonymous': False,
+                'identifier': 'foo@bar.com'
+            })
+
+            self.assertEqual(httpResult[0], 202)
+
     def test_send_with_version(self):
         client = raygunprovider.RaygunSender(self.apiKey)
         client.set_version('v1.0.0')

--- a/python3/raygun4py/raygunprovider.py
+++ b/python3/raygun4py/raygunprovider.py
@@ -77,7 +77,7 @@ class RaygunSender:
         if callable(callback):
             self.grouping_key_callback = callback
 
-    def send_exception(self, exception=None, exc_info=None, **kwargs):
+    def send_exception(self, exception=None, exc_info=None, user_override=None, **kwargs):
         options = {
             'transmitLocalVariables': self.transmit_local_variables,
             'transmitGlobalVariables': self.transmit_global_variables
@@ -94,7 +94,7 @@ class RaygunSender:
             errorMessage = raygunmsgs.RaygunErrorMessage(exc_type, exc_value, exc_traceback, options)
 
         tags, custom_data, http_request, extra_environment_data = self._parse_args(kwargs)
-        message = self._create_message(errorMessage, tags, custom_data, http_request, extra_environment_data)
+        message = self._create_message(errorMessage, tags, custom_data, http_request, extra_environment_data, user_override)
         message = self._transform_message(message)
 
         if message is not None:
@@ -113,7 +113,7 @@ class RaygunSender:
 
         return tags, custom_data, http_request, extra_environment_data
 
-    def _create_message(self, raygunExceptionMessage, tags, user_custom_data, http_request, extra_environment_data):
+    def _create_message(self, raygunExceptionMessage, tags, user_custom_data, http_request, extra_environment_data, user_override=None):
         options = {
             'transmit_environment_variables': self.transmit_environment_variables
         }
@@ -127,7 +127,7 @@ class RaygunSender:
             .set_tags(tags) \
             .set_customdata(user_custom_data) \
             .set_request_details(http_request) \
-            .set_user(self.user) \
+            .set_user(user_override if user_override else self.user) \
             .build()
 
     def _transform_message(self, message):

--- a/python3/tests/test_functional.py
+++ b/python3/tests/test_functional.py
@@ -103,6 +103,30 @@ class TestRaygun4PyFunctional(unittest.TestCase):
 
             self.assertEqual(httpResult[0], 202)
 
+    def test_sending_user_override(self):
+        client = raygunprovider.RaygunSender(self.apiKey)
+        client.set_user({
+            'firstName': 'baz',
+            'fullName': 'baz bar',
+            'email': 'baz@bar.com',
+            'isAnonymous': False,
+            'identifier': 'baz@bar.com'
+          })
+
+        try:
+            raise Exception("Raygun4py3 manual sending test - user override")
+        except:
+            exc_info = sys.exc_info()
+            httpResult = client.send_exception(exc_info=exc_info, user_override={
+                'firstName': 'foo',
+                'fullName': 'foo bar',
+                'email': 'foo@bar.com',
+                'isAnonymous': False,
+                'identifier': 'foo@bar.com'
+            })
+
+            self.assertEqual(httpResult[0], 202)
+
     def log_send(self, logger):
         try:
             raise Exception("Raygun4py3 Logging Test")
@@ -167,7 +191,7 @@ class TestRaygun4PyFunctional(unittest.TestCase):
             raise Exception("Raygun4py3 functional test - on_before_send")
         except Exception as e:
             httpResult = client.send_exception(e, exc_info = sys.exc_info())
-        
+
         self.assertEqual(httpResult[0], 202)
 
     def test_before_send_callback_sets_none_cancels_send(self):
@@ -178,7 +202,7 @@ class TestRaygun4PyFunctional(unittest.TestCase):
             raise Exception("Raygun4py3 functional test - on_before_send")
         except Exception as e:
             result = client.send_exception(e, exc_info = sys.exc_info())
-        
+
         self.assertIsNone(result)
 
     def test_request(self):
@@ -260,7 +284,7 @@ class TestRaygun4PyFunctional(unittest.TestCase):
         except Exception as e:
             result = client.send_exception(httpRequest={})
 
-            
+
 def before_send_mutate_payload(message):
     message['newKey'] = 'newValue'
     return message


### PR DESCRIPTION
**The problem**
Our flask app is a stateless API servers that supports many users concurrently.

Calling set_user via the api fails for our app with `'Connection aborted.', OSError("(32, 'EPIPE')")` when attempting to set_user in on_before_send in the production environment ((works fine locally)). The set up worked locally but when it is in a concurrent environment it starts to abort connections. I believe the connection is terminated because the raygun variable has been over written before sending the payload.

**The solution**
By providing an entry point for atomically setting the user at the same time we send the exception, we should avoid this collision.