### PR TITLE
fix(provider)!: `RaygunMessage` object in `on_grouping_key` method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -353,9 +353,9 @@ Customer data can be passed in which will be displayed in the Raygun web app. Th
 Custom grouping logic
 ---------------------
 
-You can create custom exception grouping logic that overrides the automatic Raygun grouping by passing in a function that accepts one parameter using this function. The callback's one parameter is an instance of RaygunMessage (python[2/3]/raygunmsgs.py), and the callback should return a string.
+You can create custom exception grouping logic that overrides the automatic Raygun grouping by passing in a function that accepts one parameter using this function. The callback's one parameter is an instance of `RaygunMessage` (`python3/raygunmsgs.py`), and the callback should return a string.
 
-The RaygunMessage instance contains all the error and state data that is about to be sent to the Raygun API. In your callback you can inspect this RaygunMessage, hash together the fields you want to group by, then return a string which is the grouping key.
+The `RaygunMessage` instance contains all the error and state data that is about to be sent to the Raygun API. In your callback you can inspect this `RaygunMessage`, hash together the fields you want to group by, then return a string which is the grouping key.
 
 This string needs to be between 1 and 100 characters long. If the callback is not set or the string isn't valid, the default automatic grouping will be used.
 
@@ -366,7 +366,7 @@ By example:
     class MyClass(object):
 
         def my_callback(self, raygun_message):
-            return raygun_message.get_error().message[:100] # Use naive message-based grouping only
+            return raygun_message['details']['error'].message[:100] # Use naive message-based grouping only
 
         def create_raygun_and_bind_callback(self):
             sender = raygunprovider.RaygunSender('api_key')

--- a/README.rst
+++ b/README.rst
@@ -366,7 +366,7 @@ By example:
     class MyClass(object):
 
         def my_callback(self, raygun_message):
-            return raygun_message['details']['error'].message[:100] # Use naive message-based grouping only
+            return raygun_message.get_error().message[:100] # Use naive message-based grouping only
 
         def create_raygun_and_bind_callback(self):
             sender = raygunprovider.RaygunSender('api_key')

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -1,4 +1,3 @@
-import copy
 import inspect
 import os
 import logging

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -15,7 +15,7 @@ except ImportError:
     USE_MULTIPROCESSING = False
 
 import platform
-from datetime import datetime
+from datetime import datetime, UTC
 
 from raygun4py import http_utilities
 
@@ -129,7 +129,7 @@ class RaygunMessageBuilder(object):
 class RaygunMessage(object):
 
     def __init__(self):
-        self.occurredOn = datetime.utcnow()
+        self.occurredOn = datetime.now(UTC)
         self.details = {}
 
     def __copy__(self):

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -138,6 +138,11 @@ class RaygunMessage(object):
     def get_details(self):
         return self.details
 
+    def set_details(self, details):
+        self.details = details
+
+    def set_error(self, error):
+        self.details["error"] = error
 
 class RaygunErrorMessage(object):
     log = logging.getLogger(__name__)

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -132,6 +132,15 @@ class RaygunMessage(object):
         self.occurredOn = datetime.utcnow()
         self.details = {}
 
+    def __copy__(self):
+        new_instance = RaygunMessage()
+        new_instance.details = self.details.copy()
+        new_instance.occurredOn = self.occurredOn
+        return new_instance
+
+    def copy(self):
+        return self.__copy__()
+
     def get_error(self):
         return self.details.get("error")
 

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -15,7 +15,7 @@ except ImportError:
     USE_MULTIPROCESSING = False
 
 import platform
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 
 from raygun4py import http_utilities
 
@@ -129,7 +129,7 @@ class RaygunMessageBuilder(object):
 class RaygunMessage(object):
 
     def __init__(self):
-        self.occurredOn = datetime.now(UTC)
+        self.occurredOn = datetime.now(timezone.utc)
         self.details = {}
 
     def __copy__(self):

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -144,6 +144,7 @@ class RaygunMessage(object):
     def set_error(self, error):
         self.details["error"] = error
 
+
 class RaygunErrorMessage(object):
     log = logging.getLogger(__name__)
 

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -1,3 +1,4 @@
+import copy
 import inspect
 import os
 import logging

--- a/python3/raygun4py/raygunprovider.py
+++ b/python3/raygun4py/raygunprovider.py
@@ -299,10 +299,12 @@ class RaygunSender:
         message = utilities.ignore_exceptions(self.ignored_exceptions, message)
 
         if message is not None:
-            message = utilities.filter_keys(self.filtered_keys, message)
-            message.get_details()["groupingKey"] = utilities.execute_grouping_key(
+            details = message.get_details()
+            details = utilities.filter_keys(self.filtered_keys, details)
+            details["groupingKey"] = utilities.execute_grouping_key(
                 self.grouping_key_callback, message
             )
+            message.set_details(details)
 
         if self.before_send_callback is not None:
             mutated_payload = self.before_send_callback(message.get_details())

--- a/python3/raygun4py/raygunprovider.py
+++ b/python3/raygun4py/raygunprovider.py
@@ -295,6 +295,7 @@ class RaygunSender:
         )
 
     def _transform_message(self, message):
+        message = message.copy()
         message = utilities.ignore_exceptions(self.ignored_exceptions, message)
 
         if message is not None:
@@ -314,6 +315,7 @@ class RaygunSender:
         return message
 
     def _post(self, raygunMessage):
+        raygunMessage = raygunMessage.copy()
         options = {
             "enforce_payload_size_limit": self.enforce_payload_size_limit,
             "log_payload_size_limit_breaches": self.log_payload_size_limit_breaches,

--- a/python3/raygun4py/raygunprovider.py
+++ b/python3/raygun4py/raygunprovider.py
@@ -299,15 +299,15 @@ class RaygunSender:
 
         if message is not None:
             message = utilities.filter_keys(self.filtered_keys, message)
-            message["details"]["groupingKey"] = utilities.execute_grouping_key(
+            message.get_details()["groupingKey"] = utilities.execute_grouping_key(
                 self.grouping_key_callback, message
             )
 
         if self.before_send_callback is not None:
-            mutated_payload = self.before_send_callback(message["details"])
+            mutated_payload = self.before_send_callback(message.get_details())
 
             if mutated_payload is not None:
-                message["details"] = mutated_payload
+                message.set_details(mutated_payload)
             else:
                 return None
 
@@ -320,17 +320,17 @@ class RaygunSender:
         }
 
         if (
-            isinstance(raygunMessage["details"]["error"], raygunmsgs.RaygunErrorMessage)
+            isinstance(raygunMessage.get_error(), raygunmsgs.RaygunErrorMessage)
             and "enforce_payload_size_limit" in options
             and options["enforce_payload_size_limit"] is True
         ):
             error = jsonpickle.loads(
-                jsonpickle.dumps(raygunMessage["details"]["error"])
+                jsonpickle.dumps(raygunMessage.get_error())
             )
 
             error.check_and_modify_payload_size(options)
 
-            raygunMessage["details"]["error"] = error
+            raygunMessage.set_error(error)
 
         json = jsonpickle.encode(raygunMessage, unpicklable=False)
 

--- a/python3/raygun4py/raygunprovider.py
+++ b/python3/raygun4py/raygunprovider.py
@@ -324,9 +324,7 @@ class RaygunSender:
             and "enforce_payload_size_limit" in options
             and options["enforce_payload_size_limit"] is True
         ):
-            error = jsonpickle.loads(
-                jsonpickle.dumps(raygunMessage.get_error())
-            )
+            error = jsonpickle.loads(jsonpickle.dumps(raygunMessage.get_error()))
 
             error.check_and_modify_payload_size(options)
 

--- a/python3/raygun4py/utilities.py
+++ b/python3/raygun4py/utilities.py
@@ -12,10 +12,10 @@ def ignore_exceptions(ignored_exceptions, message):
 
 
 def filter_keys(filtered_keys, object):
-    iteration_target = object
-
     if isinstance(object, raygunmsgs.RaygunMessage):
         iteration_target = dict(object.__dict__)
+    else:
+        iteration_target = dict(object)
 
     for key in iter(iteration_target.keys()):
         if isinstance(iteration_target[key], dict):
@@ -31,8 +31,9 @@ def filter_keys(filtered_keys, object):
                         iteration_target[key] = "<filtered>"
 
     if isinstance(object, raygunmsgs.RaygunMessage):
-        object.__dict__.update(iteration_target)
-        return object
+        updated_object = object.copy()
+        updated_object.__dict__.update(iteration_target)
+        return updated_object
 
     return iteration_target
 

--- a/python3/raygun4py/utilities.py
+++ b/python3/raygun4py/utilities.py
@@ -1,7 +1,5 @@
 import re
 
-from raygun4py import raygunmsgs
-
 
 def ignore_exceptions(ignored_exceptions, message):
     classname = message.get_error().get_classname()

--- a/python3/raygun4py/utilities.py
+++ b/python3/raygun4py/utilities.py
@@ -11,11 +11,11 @@ def ignore_exceptions(ignored_exceptions, message):
     return message
 
 
-def filter_keys(filtered_keys, object):
-    if isinstance(object, raygunmsgs.RaygunMessage):
-        iteration_target = dict(object.__dict__)
+def filter_keys(filtered_keys, obj):
+    if isinstance(obj, raygunmsgs.RaygunMessage):
+        iteration_target = dict(obj.__dict__)
     else:
-        iteration_target = dict(object)
+        iteration_target = dict(obj)
 
     for key in iter(iteration_target.keys()):
         if isinstance(iteration_target[key], dict):
@@ -30,8 +30,8 @@ def filter_keys(filtered_keys, object):
                     if sanitised_key in key:
                         iteration_target[key] = "<filtered>"
 
-    if isinstance(object, raygunmsgs.RaygunMessage):
-        updated_object = object.copy()
+    if isinstance(obj, raygunmsgs.RaygunMessage):
+        updated_object = obj.copy()
         updated_object.__dict__.update(iteration_target)
         return updated_object
 

--- a/python3/raygun4py/utilities.py
+++ b/python3/raygun4py/utilities.py
@@ -12,10 +12,17 @@ def ignore_exceptions(ignored_exceptions, message):
 
 
 def filter_keys(filtered_keys, obj):
-    if isinstance(obj, raygunmsgs.RaygunMessage):
-        iteration_target = dict(obj.__dict__)
-    else:
-        iteration_target = dict(obj)
+    """
+    Filter keys from a dictionary.
+
+    Parameters:
+        filtered_keys (list): A list of keys to filter.
+        obj (dict): The dictionary to filter.
+
+    Returns:
+        dict: The filtered dictionary.
+    """
+    iteration_target = dict(obj)
 
     for key in iter(iteration_target.keys()):
         if isinstance(iteration_target[key], dict):
@@ -29,11 +36,6 @@ def filter_keys(filtered_keys, obj):
 
                     if sanitised_key in key:
                         iteration_target[key] = "<filtered>"
-
-    if isinstance(obj, raygunmsgs.RaygunMessage):
-        updated_object = obj.copy()
-        updated_object.__dict__.update(iteration_target)
-        return updated_object
 
     return iteration_target
 

--- a/python3/raygun4py/utilities.py
+++ b/python3/raygun4py/utilities.py
@@ -15,7 +15,7 @@ def filter_keys(filtered_keys, object):
     iteration_target = object
 
     if isinstance(object, raygunmsgs.RaygunMessage):
-        iteration_target = object.__dict__
+        iteration_target = dict(object.__dict__)
 
     for key in iter(iteration_target.keys()):
         if isinstance(iteration_target[key], dict):
@@ -29,6 +29,10 @@ def filter_keys(filtered_keys, object):
 
                     if sanitised_key in key:
                         iteration_target[key] = "<filtered>"
+
+    if isinstance(object, raygunmsgs.RaygunMessage):
+        object.__dict__.update(iteration_target)
+        return object
 
     return iteration_target
 

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -159,6 +159,13 @@ class TestRaygunMessageBuilder(unittest.TestCase):
             self.builder.raygunMessage.details["environment"]["environmentVariables"]
         )
 
+    def test_get_error(self):
+        self.builder.set_exception_details(raygunmsgs.RaygunErrorMessage(Exception, None, None, {}))
+        self.assertIsNotNone(self.builder.raygunMessage.get_error())
+
+    def test_get_details(self):
+        self.builder.set_exception_details(raygunmsgs.RaygunErrorMessage(Exception, None, None, {}))
+        self.assertIsNotNone(self.builder.raygunMessage.get_details())
 
 class TestRaygunErrorMessage(unittest.TestCase):
     ONEHUNDRED_AND_FIFTY_KB = 150 * 1024

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -181,6 +181,7 @@ class TestRaygunMessageBuilder(unittest.TestCase):
         message.set_details({"foo": "bar"})
         self.assertEqual(message.get_details(), {"foo": "bar"})
 
+
 class TestRaygunErrorMessage(unittest.TestCase):
     ONEHUNDRED_AND_FIFTY_KB = 150 * 1024
 

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -160,12 +160,17 @@ class TestRaygunMessageBuilder(unittest.TestCase):
         )
 
     def test_get_error(self):
-        self.builder.set_exception_details(raygunmsgs.RaygunErrorMessage(Exception, None, None, {}))
+        self.builder.set_exception_details(
+            raygunmsgs.RaygunErrorMessage(Exception, None, None, {})
+        )
         self.assertIsNotNone(self.builder.raygunMessage.get_error())
 
     def test_get_details(self):
-        self.builder.set_exception_details(raygunmsgs.RaygunErrorMessage(Exception, None, None, {}))
+        self.builder.set_exception_details(
+            raygunmsgs.RaygunErrorMessage(Exception, None, None, {})
+        )
         self.assertIsNotNone(self.builder.raygunMessage.get_details())
+
 
 class TestRaygunErrorMessage(unittest.TestCase):
     ONEHUNDRED_AND_FIFTY_KB = 150 * 1024

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -171,6 +171,15 @@ class TestRaygunMessageBuilder(unittest.TestCase):
         )
         self.assertIsNotNone(self.builder.raygunMessage.get_details())
 
+    def test_set_error(self):
+        message = raygunmsgs.RaygunMessage()
+        message.set_error("Error")
+        self.assertEqual(message.get_error(), "Error")
+
+    def test_set_details(self):
+        message = raygunmsgs.RaygunMessage()
+        message.set_details({"foo": "bar"})
+        self.assertEqual(message.get_details(), {"foo": "bar"})
 
 class TestRaygunErrorMessage(unittest.TestCase):
     ONEHUNDRED_AND_FIFTY_KB = 150 * 1024

--- a/python3/tests/test_raygunprovider.py
+++ b/python3/tests/test_raygunprovider.py
@@ -140,14 +140,14 @@ class TestGroupingKey(unittest.TestCase):
     def test_message_with_error(self):
         msg = self.create_dummy_message()
         self.sender.on_grouping_key(self.the_callback_with_error)
-        msg =self.sender._transform_message(msg)
+        msg = self.sender._transform_message(msg)
         self.assertEqual(msg.get_details()["groupingKey"], "Exception: None")
 
     def test_groupingkey_is_not_none_with_callback(self):
         msg = self.create_dummy_message()
         self.sender.on_grouping_key(self.the_callback)
         self.key = "foo"
-        msg =self.sender._transform_message(msg)
+        msg = self.sender._transform_message(msg)
 
         self.assertIsNotNone(msg.get_details()["groupingKey"])
 
@@ -163,7 +163,7 @@ class TestGroupingKey(unittest.TestCase):
         msg = self.create_dummy_message()
         self.sender.on_grouping_key(self.the_callback)
         self.key = "foo"
-        msg =self.sender._transform_message(msg)
+        msg = self.sender._transform_message(msg)
 
         self.assertIsInstance(msg.get_details()["groupingKey"], str)
 
@@ -191,7 +191,7 @@ class TestGroupingKey(unittest.TestCase):
         for i in range(0, 99):
             self.key += "a"
 
-        msg =self.sender._transform_message(msg)
+        msg = self.sender._transform_message(msg)
         self.assertEqual(msg.get_details()["groupingKey"], self.key)
 
     def test_groupingkey_is_none_when_too_long_string_returned_from_callback(self):

--- a/python3/tests/test_raygunprovider.py
+++ b/python3/tests/test_raygunprovider.py
@@ -126,6 +126,9 @@ class TestGroupingKey(unittest.TestCase):
     def the_callback(self, raygun_message):
         return self.key
 
+    def the_callback_with_error(self, raygun_message):
+        return raygun_message.get_error().message[:100]
+
     def create_dummy_message(self):
         self.sender = raygunprovider.RaygunSender("apikey")
 
@@ -133,6 +136,12 @@ class TestGroupingKey(unittest.TestCase):
         errorMessage = raygunmsgs.RaygunErrorMessage(Exception, None, None, {})
         msg.set_exception_details(errorMessage)
         return msg.build()
+
+    def test_message_with_error(self):
+        msg = self.create_dummy_message()
+        self.sender.on_grouping_key(self.the_callback_with_error)
+        self.sender._transform_message(msg)
+        self.assertEqual(msg.get_details()["groupingKey"], "Exception: None")
 
     def test_groupingkey_is_not_none_with_callback(self):
         msg = self.create_dummy_message()

--- a/python3/tests/test_raygunprovider.py
+++ b/python3/tests/test_raygunprovider.py
@@ -140,14 +140,14 @@ class TestGroupingKey(unittest.TestCase):
     def test_message_with_error(self):
         msg = self.create_dummy_message()
         self.sender.on_grouping_key(self.the_callback_with_error)
-        self.sender._transform_message(msg)
+        msg =self.sender._transform_message(msg)
         self.assertEqual(msg.get_details()["groupingKey"], "Exception: None")
 
     def test_groupingkey_is_not_none_with_callback(self):
         msg = self.create_dummy_message()
         self.sender.on_grouping_key(self.the_callback)
         self.key = "foo"
-        self.sender._transform_message(msg)
+        msg =self.sender._transform_message(msg)
 
         self.assertIsNotNone(msg.get_details()["groupingKey"])
 
@@ -155,7 +155,7 @@ class TestGroupingKey(unittest.TestCase):
         msg = self.create_dummy_message()
         self.sender.on_grouping_key(self.the_callback)
         self.key = "foo"
-        self.sender._transform_message(msg)
+        msg = self.sender._transform_message(msg)
 
         self.assertEqual(msg.get_details()["groupingKey"], "foo")
 
@@ -163,7 +163,7 @@ class TestGroupingKey(unittest.TestCase):
         msg = self.create_dummy_message()
         self.sender.on_grouping_key(self.the_callback)
         self.key = "foo"
-        self.sender._transform_message(msg)
+        msg =self.sender._transform_message(msg)
 
         self.assertIsInstance(msg.get_details()["groupingKey"], str)
 
@@ -171,7 +171,7 @@ class TestGroupingKey(unittest.TestCase):
         msg = self.create_dummy_message()
         self.sender.on_grouping_key(self.the_callback)
         self.key = object
-        self.sender._transform_message(msg)
+        msg = self.sender._transform_message(msg)
 
         self.assertIsNone(msg.get_details()["groupingKey"])
 
@@ -179,7 +179,7 @@ class TestGroupingKey(unittest.TestCase):
         msg = self.create_dummy_message()
         self.sender.on_grouping_key(self.the_callback)
         self.key = ""
-        self.sender._transform_message(msg)
+        msg = self.sender._transform_message(msg)
 
         self.assertIsNone(msg.get_details()["groupingKey"])
 
@@ -191,7 +191,7 @@ class TestGroupingKey(unittest.TestCase):
         for i in range(0, 99):
             self.key += "a"
 
-        self.sender._transform_message(msg)
+        msg =self.sender._transform_message(msg)
         self.assertEqual(msg.get_details()["groupingKey"], self.key)
 
     def test_groupingkey_is_none_when_too_long_string_returned_from_callback(self):
@@ -202,7 +202,7 @@ class TestGroupingKey(unittest.TestCase):
         for i in range(0, 100):
             self.key += "a"
 
-        self.sender._transform_message(msg)
+        msg = self.sender._transform_message(msg)
         self.assertIsNone(msg.get_details()["groupingKey"])
 
 

--- a/python3/tests/test_utilities.py
+++ b/python3/tests/test_utilities.py
@@ -1,6 +1,5 @@
 import unittest
 
-from raygun4py import raygunmsgs
 from raygun4py import utilities
 
 

--- a/python3/tests/test_utilities.py
+++ b/python3/tests/test_utilities.py
@@ -29,16 +29,6 @@ class TestRaygunUtilities(unittest.TestCase):
         self.assertEqual(test_obj["foobz"], "<filtered>")
         self.assertEqual(test_obj["fooqx"], "<filtered>")
 
-    def test_filter_keys_raygun_message(self):
-        test_obj = {"foo": "bar", "baz": "qux"}
-        message = raygunmsgs.RaygunMessage()
-        message.set_details(test_obj)
-
-        self.assertTrue(isinstance(message, raygunmsgs.RaygunMessage))
-        message = utilities.filter_keys(["foo"], message)
-        self.assertTrue(isinstance(message, raygunmsgs.RaygunMessage))
-        self.assertEqual(message.get_details()["foo"], "<filtered>")
-
 
 def main():
     unittest.main()

--- a/python3/tests/test_utilities.py
+++ b/python3/tests/test_utilities.py
@@ -1,5 +1,6 @@
 import unittest
 
+from raygun4py import raygunmsgs
 from raygun4py import utilities
 
 
@@ -27,6 +28,16 @@ class TestRaygunUtilities(unittest.TestCase):
         self.assertEqual(test_obj["foobr"], "<filtered>")
         self.assertEqual(test_obj["foobz"], "<filtered>")
         self.assertEqual(test_obj["fooqx"], "<filtered>")
+
+    def test_filter_keys_raygun_message(self):
+        test_obj = {"foo": "bar", "baz": "qux"}
+        message = raygunmsgs.RaygunMessage()
+        message.set_details(test_obj)
+
+        self.assertTrue(isinstance(message, raygunmsgs.RaygunMessage))
+        message = utilities.filter_keys(["foo"], message)
+        self.assertTrue(isinstance(message, raygunmsgs.RaygunMessage))
+        self.assertEqual(message.get_details()["foo"], "<filtered>")
 
 
 def main():

--- a/python3/tests/test_utilities.py
+++ b/python3/tests/test_utilities.py
@@ -7,14 +7,14 @@ class TestRaygunUtilities(unittest.TestCase):
     def test_filter_keys(self):
         test_obj = {"foo": "bar", "baz": "qux"}
 
-        utilities.filter_keys(["foo"], test_obj)
+        test_obj = utilities.filter_keys(["foo"], test_obj)
 
         self.assertEqual(test_obj["foo"], "<filtered>")
 
     def test_filter_keys_recursive(self):
         test_obj = {"foo": "bar", "baz": "qux", "boo": {"foo": "qux"}}
 
-        utilities.filter_keys(["foo"], test_obj)
+        test_obj = utilities.filter_keys(["foo"], test_obj)
 
         self.assertEqual(test_obj["foo"], "<filtered>")
         self.assertEqual(test_obj["boo"]["foo"], "<filtered>")
@@ -22,7 +22,7 @@ class TestRaygunUtilities(unittest.TestCase):
     def test_filter_keys_with_wildcard(self):
         test_obj = {"foobr": "bar", "foobz": "baz", "fooqx": "foo", "baz": "qux"}
 
-        utilities.filter_keys(["foo*"], test_obj)
+        test_obj = utilities.filter_keys(["foo*"], test_obj)
 
         self.assertEqual(test_obj["foobr"], "<filtered>")
         self.assertEqual(test_obj["foobz"], "<filtered>")


### PR DESCRIPTION
### Description :memo:

**Purpose**: 

In the ticket https://github.com/MindscapeHQ/raygun4py/issues/96 the customer reported that the object provided to the `on_grouping_key` callback was not a `RaygunMessage` object but rather a Dictionary.

This was caused by a bug in the `filter_keys` method as the customer pointed out.

**Approach**: 

After some iterations, the `filter_keys` function has been changed so it does not accept `RaygunMessage` objects, and instead it can only be used with dictionaries (e.g. the `RaygunMessage.details`). This simplifies the implementation and avoids bugs like the one reported in #96 where the `RaygunMessage` was overridden.

This ensures that `filter_keys` doesn't break the class definition of `RaygunMessage`.

Then, the rest of the `_post()` method had to be fixed to access the `details` of the `RaygunMessage` object correctly.

For that I created methods to `set_details` and `set_error`.

As well, I created unit tests that check that what the documentation says is correct.

Finally, I also fixed the documentation formatting a bit.

This is potentially a breaking change if customers were accessing the object as a dictionary, as they will have to change the code, so a major version should be released.

While implementing this fix, I also made sure that functions are pure and that they don't modify the provided `RaygunMessage`, but rather modify a copy and then return it.

**Type of change**

- [x] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [ ] `chore:` Chore task, release or small impact change
- [ ] `ci:` CI configuration change
- [ ] Other type of change (specify)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


**Related issues**

- Closes #96 

### Test plan :test_tube:

- Tested through existing and new unit tests

### Author to check :eyeglasses:

- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:

- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)