### PR TITLE
perf: improve enforce_payload_size_limit

### DIFF
--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -202,7 +202,7 @@ class RaygunErrorMessage(object):
                     and options["transmitGlobalVariables"] is True
                     and len(frames) > 0
                 ):
-                    self.globalVariables = frames[-1][0].f_globals
+                    self.globalVariables = frames[-1][0].f_globals.copy()
         except Exception:
             pass
         finally:

--- a/python3/raygun4py/raygunprovider.py
+++ b/python3/raygun4py/raygunprovider.py
@@ -328,7 +328,7 @@ class RaygunSender:
             and "enforce_payload_size_limit" in options
             and options["enforce_payload_size_limit"] is True
         ):
-            error = jsonpickle.loads(jsonpickle.dumps(raygunMessage.get_error()))
+            error = raygunMessage.get_error()
 
             error.check_and_modify_payload_size(options)
 


### PR DESCRIPTION
### Description :memo:

**Purpose**: 

As reported internally:

> I needed to initialise Raygun with `config={'enforce_payload_size_limit': False})`
> 
> Without this setting, I ran into internal issues with Raygun4Py in the current version (inside of its JSON handling code). I didn't investigate that further at this stage and will let [@]miquelbeltran know about the issue in the RG4Py repo.

I am not sure what exactly the error here was, but I investigated a bit and saw that the code handling the `enforce_payload_size_limit` was performing a deep copy of the error payload before applying the size limits:

```py
error = jsonpickle.loads(jsonpickle.dumps(raygunMessage.get_error()))
```

This seems unnecessary, as we are just going to send the payload and then discard it.


**Approach**: 

The code has been simplified, and now it uses the error payload directly:

```py
error = raygunMessage.get_error()
```

**Type of change**

<!-- Select all that are relevant -->

- [ ] `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] `feat:` New feature (non-breaking change which adds functionality)
- [ ] `chore:` Chore task, release or small impact change
- [ ] `ci:` CI configuration change
- [x] Other type of change (specify)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Updates**

- Modified the `enforce_payload_size_limit` handling code

**Related issues**

- Internal

### Test plan :test_tube:

Run the tests and samples to verify everything works as before

### Author to check :eyeglasses:

- [ ] Project and all contained modules builds successfully
- [ ] Self-/dev-tested 
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:

- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)