### PR TITLE
chore: Release 8.0.0

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -22,7 +22,15 @@ jobs:
         python-version: ${{ matrix.python-version }}
         check-latest: true
     
-    - name: Install dependencies
+    - name: Install dependencies from legacy dev extra
+      if: matrix.python-version == '3.10'
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build -e ".[dev]"
+        python -m pip check
+
+    - name: Install dependencies from dependency groups
+      if: matrix.python-version != '3.10'
       run: |
         python -m pip install --upgrade pip
         python -m pip install -e . --group dev

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -62,6 +62,7 @@ jobs:
       run: |
         python -m pip install --upgrade "pip>=26.1"
         python -m pip install -r pylock.dev.toml
+        python -m pip install --no-deps -e .
 
     - name: Check formatting with ruff
       run: |

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -e . --group dev
+        python -m pip check
     
     - name: Check formatting with ruff
       run: |
@@ -60,9 +61,10 @@ jobs:
 
     - name: Install locked development environment
       run: |
-        python -m pip install --upgrade "pip>=26.1"
+        python -m pip install --upgrade "pip==26.1.2"
         python -m pip install -r pylock.dev.toml
-        python -m pip install --no-deps -e .
+        python -m pip install --no-deps --no-build-isolation -e .
+        python -m pip check
 
     - name: Check formatting with ruff
       run: |
@@ -72,6 +74,10 @@ jobs:
       run: |
         ruff check python3/
 
+    - name: Check types with mypy
+      run: |
+        mypy python3/raygun4py
+
     - name: Run tests with coverage
       env:
         RAYGUN_API_KEY: ${{ secrets.RAYGUN_API_KEY }}
@@ -80,4 +86,4 @@ jobs:
 
     - name: Build package
       run: |
-        python -m build
+        python -m build --no-isolation

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4
@@ -25,8 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build
-        pip install -e .[dev]
+        python -m pip install -e . --group dev
     
     - name: Check formatting with ruff
       run: |
@@ -42,6 +41,42 @@ jobs:
       run: |
         pytest --cov=python3/raygun4py --cov-report=term-missing
     
+    - name: Build package
+      run: |
+        python -m build
+
+  locked-dev-install:
+    name: Locked dev install
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.13"
+        check-latest: true
+
+    - name: Install locked development environment
+      run: |
+        python -m pip install --upgrade "pip>=26.1"
+        python -m pip install -r pylock.dev.toml
+
+    - name: Check formatting with ruff
+      run: |
+        ruff format --check python3/
+
+    - name: Lint with ruff
+      run: |
+        ruff check python3/
+
+    - name: Run tests with coverage
+      env:
+        RAYGUN_API_KEY: ${{ secrets.RAYGUN_API_KEY }}
+      run: |
+        pytest --cov=python3/raygun4py --cov-report=term-missing
+
     - name: Build package
       run: |
         python -m build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Bug fixes:
 
 Internal changes:
   - Add Python dependency groups for development, test, linting, typing, and build tooling.
-  - Keep the existing `dev` extra for backwards-compatible contributor installs.
+  - Keep the existing `dev` extra for backwards-compatible contributor installs and exercise it in the Python 3.10 CI job.
   - Add an optional `pylock.dev.toml` hash-verified dependency snapshot for the locked CI environment.
   - Add a locked development environment CI job with locked build tooling and dependency consistency checks, while keeping the main Python matrix on unlocked dependency resolution.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Breaking changes:
   - Drop support for Python 3.9. Raygun4Py now requires Python 3.10 or newer.
 
+Bug fixes:
+  - Preserve current jsonpickle serialization behavior and use Flask's supported package metadata API ahead of upstream deprecations.
+
 Internal changes:
   - Add Python dependency groups for development, test, linting, typing, and build tooling.
   - Keep the existing `dev` extra for backwards-compatible contributor installs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Breaking changes:
   - Drop support for Python 3.9. Raygun4Py now requires Python 3.10 or newer.
 
 Bug fixes:
-  - Preserve current jsonpickle serialization behavior and use Flask's supported package metadata API ahead of upstream deprecations.
+  - Preserve the existing jsonpickle payload wire format and use Flask's supported package metadata API ahead of upstream deprecations.
 
 Internal changes:
   - Add Python dependency groups for development, test, linting, typing, and build tooling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 8.0.0 (16/06/26):
+
+Breaking changes:
+  - Drop support for Python 3.9. Raygun4Py now requires Python 3.10 or newer.
+
+Internal changes:
+  - Add Python dependency groups for development, test, linting, typing, and build tooling.
+  - Keep the existing `dev` extra for backwards-compatible contributor installs.
+  - Add an optional `pylock.dev.toml` development lockfile for reproducible contributor and CI installs.
+  - Add a locked development environment CI job while keeping the main Python matrix on unlocked dependency resolution.
+
 ## 7.0.0 (23/01/26):
 
 Potentially breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 8.0.0 (Unreleased):
+## 8.0.0 (23/07/26):
 
 Breaking changes:
   - Drop support for Python 3.9. Raygun4Py now requires Python 3.10 or newer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 8.0.0 (16/06/26):
+## 8.0.0 (Unreleased):
 
 Breaking changes:
   - Drop support for Python 3.9. Raygun4Py now requires Python 3.10 or newer.
@@ -6,8 +6,8 @@ Breaking changes:
 Internal changes:
   - Add Python dependency groups for development, test, linting, typing, and build tooling.
   - Keep the existing `dev` extra for backwards-compatible contributor installs.
-  - Add an optional `pylock.dev.toml` development lockfile for reproducible contributor and CI installs.
-  - Add a locked development environment CI job while keeping the main Python matrix on unlocked dependency resolution.
+  - Add an optional `pylock.dev.toml` hash-verified dependency snapshot for the locked CI environment.
+  - Add a locked development environment CI job with locked build tooling and dependency consistency checks, while keeping the main Python matrix on unlocked dependency resolution.
 
 ## 7.0.0 (23/01/26):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Breaking changes:
   - Drop support for Python 3.9. Raygun4Py now requires Python 3.10 or newer.
 
 Bug fixes:
-  - Preserve the existing jsonpickle payload wire format and use Flask's supported package metadata API ahead of upstream deprecations.
+  - Preserve the existing jsonpickle payload wire format while isolating jsonpickle 4.1.2's transitional warning.
+  - Use Flask's supported package metadata API, with a fallback when distribution metadata is unavailable so error reporting does not mask the original exception.
 
 Internal changes:
   - Add Python dependency groups for development, test, linting, typing, and build tooling.

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -50,14 +50,25 @@ python3 -m pip lock \
 
 The explicit runtime requirements keep the local editable package out of the lock without manual lock-file edits. Review this command whenever `[project].dependencies` changes.
 
-To run tests with coverage:
+### Tests
+
+Run the unit and middleware tests with coverage:
+
 ```bash
 pytest --cov=python3/raygun4py --cov-report=term-missing
 ```
 
+The functional tests send deliberate test errors to Raygun and are skipped when `RAYGUN_API_KEY` is not set. Run them only against a non-production Raygun application:
+
+```bash
+RAYGUN_API_KEY="your_test_api_key" pytest python3/tests/test_functional.py -v
+```
+
+Do not commit the API key or store it in this repository.
+
 ### Code Quality
 
-This project uses [Ruff](https://docs.astral.sh/ruff/) for linting and formatting.
+This project uses [Ruff](https://docs.astral.sh/ruff/) for linting and formatting and mypy for static type checking.
 
 ```bash
 # Check formatting
@@ -71,6 +82,15 @@ ruff check python3/
 
 # Fix auto-fixable lint issues
 ruff check --fix python3/
+
+# Check types
+mypy python3/raygun4py
+```
+
+Build with the locked build toolchain after installing `pylock.dev.toml` as described above:
+
+```bash
+python3 -m build --no-isolation
 ```
 
 - Remember to deactivate the virtual environment when you're done: `deactivate`

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,6 +1,6 @@
 ## Getting Started with Local Development
 
-Before starting, you'll need to ensure you have the appropriate version of Python installed.
+Before starting, you'll need to ensure you have Python 3.10 or newer installed.
 
 ### Python 3
 
@@ -8,10 +8,17 @@ Before starting, you'll need to ensure you have the appropriate version of Pytho
 2. Navigate to the project directory: `cd <project folder>`
 3. Create a new virtual environment using Python 3: `python3 -m virtualenv venv3`
 4. Activate the virtual environment. On Windows, use `venv3\Scripts\activate`. On Unix or MacOS, use `source venv3/bin/activate`.
-5. Install the development dependencies and prepare local package: `python3 -m pip install -e .[dev]`
-6. Run tests with the command: 
+5. Upgrade pip: `python3 -m pip install --upgrade pip`
+6. Install the development dependencies and prepare the local package: `python3 -m pip install -e . --group dev`
+7. Run tests with the command:
 ```bash
 pytest
+```
+
+The legacy development extra is still available for older tooling that does not support dependency groups:
+
+```bash
+python3 -m pip install -e .[dev]
 ```
 
 To run tests with coverage:
@@ -38,4 +45,3 @@ ruff check --fix python3/
 ```
 
 - Remember to deactivate the virtual environment when you're done: `deactivate`
-

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -21,6 +21,8 @@ The legacy development extra is still available for older tooling that does not 
 python3 -m pip install -e .[dev]
 ```
 
+The dependency groups are the authoritative definition of the complete contributor environment and include the build toolchain. The legacy `dev` extra remains a compatibility interface and is exercised by the Python 3.10 CI job. When changing a requirement shared by both declarations in `pyproject.toml`, update both lists together.
+
 ### Locked development install
 
 The repository includes `pylock.dev.toml` as a hash-verified Python dependency snapshot for the locked CI job. It is not part of Raygun4Py's public installation contract; applications that use Raygun4Py should manage their own lock files.

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -21,6 +21,18 @@ The legacy development extra is still available for older tooling that does not 
 python3 -m pip install -e .[dev]
 ```
 
+### Reproducible development install
+
+The repository includes `pylock.dev.toml` as a known-good development environment snapshot for contributors and CI. It is not part of Raygun4Py's public installation contract; applications that use Raygun4Py should manage their own lock files.
+
+To install from the lock file with pip 26.1 or newer:
+
+```bash
+python3 -m pip install -r pylock.dev.toml
+```
+
+The lock file is generated on Linux with Python 3.13, so prefer the dependency-group install above when validating compatibility across other Python versions or platforms.
+
 To run tests with coverage:
 ```bash
 pytest --cov=python3/raygun4py --cov-report=term-missing

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -29,9 +29,10 @@ To install from the lock file with pip 26.1 or newer:
 
 ```bash
 python3 -m pip install -r pylock.dev.toml
+python3 -m pip install --no-deps -e .
 ```
 
-The lock file is generated on Linux with Python 3.13, so prefer the dependency-group install above when validating compatibility across other Python versions or platforms.
+The lock file contains Raygun4Py's runtime and development dependencies, but not the local package itself. The second command installs the local package without re-resolving dependencies. The lock file is generated on Linux with Python 3.13, so prefer the dependency-group install above when validating compatibility across other Python versions or platforms.
 
 To run tests with coverage:
 ```bash

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -8,7 +8,7 @@ Before starting, you'll need to ensure you have Python 3.10 or newer installed.
 2. Navigate to the project directory: `cd <project folder>`
 3. Create a new virtual environment using Python 3: `python3 -m virtualenv venv3`
 4. Activate the virtual environment. On Windows, use `venv3\Scripts\activate`. On Unix or MacOS, use `source venv3/bin/activate`.
-5. Upgrade pip: `python3 -m pip install --upgrade pip`
+5. Upgrade to pip 25.1 or newer, which supports dependency groups: `python3 -m pip install --upgrade "pip>=25.1"`
 6. Install the development dependencies and prepare the local package: `python3 -m pip install -e . --group dev`
 7. Run tests with the command:
 ```bash
@@ -21,18 +21,34 @@ The legacy development extra is still available for older tooling that does not 
 python3 -m pip install -e .[dev]
 ```
 
-### Reproducible development install
+### Locked development install
 
-The repository includes `pylock.dev.toml` as a known-good development environment snapshot for contributors and CI. It is not part of Raygun4Py's public installation contract; applications that use Raygun4Py should manage their own lock files.
+The repository includes `pylock.dev.toml` as a hash-verified Python dependency snapshot for the locked CI job. It is not part of Raygun4Py's public installation contract; applications that use Raygun4Py should manage their own lock files.
 
-To install from the lock file with pip 26.1 or newer:
+The lock file uses pip's experimental PEP 751 support and is generated with CPython 3.13.5 on Linux x86-64 and pip 26.1.2. Install it on CPython 3.13 in that environment with the same pip version:
 
 ```bash
+python3 -m pip install --upgrade "pip==26.1.2"
 python3 -m pip install -r pylock.dev.toml
-python3 -m pip install --no-deps -e .
+python3 -m pip install --no-deps --no-build-isolation -e .
+python3 -m pip check
 ```
 
-The lock file contains Raygun4Py's runtime and development dependencies, but not the local package itself. The second command installs the local package without re-resolving dependencies. The lock file is generated on Linux with Python 3.13, so prefer the dependency-group install above when validating compatibility across other Python versions or platforms.
+The lock file contains Raygun4Py's runtime, development, and build dependencies, but not the local package itself. The editable install uses the locked build backend without re-resolving dependencies or creating an isolated build environment. Prefer the dependency-group install above when validating compatibility across other Python versions or platforms.
+
+Regenerate the lock file in the same target environment after changing runtime or development dependencies:
+
+```bash
+python3 -m pip install --upgrade "pip==26.1.2"
+python3 -m pip lock \
+  "jsonpickle>=4.0.4" \
+  "blinker>=1.3.0" \
+  "requests>=2.9.1" \
+  --group dev \
+  --output pylock.dev.toml
+```
+
+The explicit runtime requirements keep the local editable package out of the lock without manual lock-file edits. Review this command whenever `[project].dependencies` changes.
 
 To run tests with coverage:
 ```bash

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Note that using a :code:`RaygunHandler` outside the scope of an :code:`except` b
 Web frameworks
 --------------
 
-Raygun4py includes dedicated middleware implementations for Django and Flask, as well as generic WSGI frameworks (Tornado, Bottle, Ginkgo etc). These are available for both Python 2.7 and Python 3.1+.
+Raygun4py includes dedicated middleware implementations for Django and Flask, as well as generic WSGI frameworks (Tornado, Bottle, Ginkgo etc). These are available for Python 3.10+.
 
 Django
 ++++++

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 raygun4py
 =========
 
-Official Raygun provider for **Python** and **PyPy**
+Official Raygun provider for **Python 3.10+** and **PyPy**
 
 **Python 2.7** is supported in versions <= 4.4.0
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,7 +27,7 @@ Update the `__version__` in the `python3/raygun4py/version.py` file.
 
 ### Update CHANGELOG.md
 
-Add a new entry in the `CHANGELOG.md` file.
+Add a new entry in the `CHANGELOG.md` file. Keep the release marked `Unreleased` while it is under review, then replace `Unreleased` with the publication date in the final release commit.
 
 Obtain a list of changes using the following git command:
 
@@ -46,6 +46,8 @@ Then push the branch and open a new PR, ask the team to review it.
 ### PR approval
 
 Once the PR has been approved, you can publish the provider.
+
+Before publishing, confirm that CI passes the unlocked Python compatibility matrix and the locked development job. If a test Raygun application is available, also run the functional tests described in `CONTRIBUTING.MD`.
 
 ### Publish to PyPi 
 

--- a/pylock.dev.toml
+++ b/pylock.dev.toml
@@ -354,13 +354,6 @@ url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be
 sha256 = "a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678"
 
 [[packages]]
-name = "raygun4py"
-
-[packages.directory]
-path = "."
-editable = true
-
-[[packages]]
 name = "requests"
 version = "2.34.2"
 

--- a/pylock.dev.toml
+++ b/pylock.dev.toml
@@ -14,25 +14,25 @@ sha256 = "571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"
 
 [[packages]]
 name = "asgiref"
-version = "3.11.1"
+version = "3.12.1"
 
 [[packages.wheels]]
-name = "asgiref-3.11.1-py3-none-any.whl"
-url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl"
+name = "asgiref-3.12.1-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl"
 
 [packages.wheels.hashes]
-sha256 = "e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133"
+sha256 = "fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094"
 
 [[packages]]
 name = "ast-serialize"
-version = "0.5.0"
+version = "0.6.0"
 
 [[packages.wheels]]
-name = "ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-url = "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+name = "ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
 
 [packages.wheels.hashes]
-sha256 = "b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809"
+sha256 = "dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7"
 
 [[packages]]
 name = "beautifulsoup4"
@@ -69,47 +69,47 @@ sha256 = "13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f"
 
 [[packages]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 
 [[packages.wheels]]
-name = "certifi-2026.5.20-py3-none-any.whl"
-url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl"
+name = "certifi-2026.6.17-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl"
 
 [packages.wheels.hashes]
-sha256 = "3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897"
+sha256 = "2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"
 
 [[packages]]
 name = "charset-normalizer"
-version = "3.4.7"
+version = "3.4.9"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+name = "charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
 
 [packages.wheels.hashes]
-sha256 = "e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd"
+sha256 = "84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33"
 
 [[packages]]
 name = "click"
-version = "8.4.1"
+version = "8.4.2"
 
 [[packages.wheels]]
-name = "click-8.4.1-py3-none-any.whl"
-url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl"
+name = "click-8.4.2-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl"
 
 [packages.wheels.hashes]
-sha256 = "482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2"
+sha256 = "e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"
 
 [[packages]]
 name = "coverage"
-version = "7.14.1"
+version = "7.15.2"
 
 [[packages.wheels]]
-name = "coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-url = "https://files.pythonhosted.org/packages/51/8c/23faf6a2343a0d17f960a4bd56c43bc7eb4cf312f774dd6ceebd82c7d8fc/coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+name = "coverage-7.15.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+url = "https://files.pythonhosted.org/packages/31/d3/06b5f1daf95f0f15ab05bd75f26ba5f3c8b33d0bb72f3aaa3cf41d1bad3a/coverage-7.15.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
 
 [packages.wheels.hashes]
-sha256 = "9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d"
+sha256 = "7dc2950a2992cd676d35c20ae63522836deeb034f08874699d14068710af3dc1"
 
 [[packages]]
 name = "coveralls"
@@ -124,14 +124,25 @@ sha256 = "bfacfda2d443c24fc90d67035027cec15015fff2dbd036427e8bf8f4953dda2e"
 
 [[packages]]
 name = "django"
-version = "6.0.6"
+version = "6.0.7"
 
 [[packages.wheels]]
-name = "django-6.0.6-py3-none-any.whl"
-url = "https://files.pythonhosted.org/packages/eb/50/23f9dc45483419a3cc2085b498b25adfbf10642b2941c73e6d2dfaffc9ab/django-6.0.6-py3-none-any.whl"
+name = "django-6.0.7-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/ba/ec/1ce5334b6a2c52ce619c23a0be8d366a57a0e080ebb2d88266e5c849157c/django-6.0.7-py3-none-any.whl"
 
 [packages.wheels.hashes]
-sha256 = "25148b1194c47c2e685e5f5e9c5d59c78b075dfd282cb9618861ba6c1708f4d2"
+sha256 = "a037427c2288443a8c02a1b02295a31c239663aa682bc50b1976afb7cf6a769e"
+
+[[packages]]
+name = "editables"
+version = "0.6"
+
+[[packages.wheels]]
+name = "editables-0.6-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/cc/0e/d095533037fc9468f947b19f2da53f869804632b508808de41e86e801797/editables-0.6-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "d70e4698078a1d033e7786d9c64e5be070d058a67c21417024d38a58ac20aa43"
 
 [[packages]]
 name = "flask"
@@ -143,6 +154,17 @@ url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0
 
 [packages.wheels.hashes]
 sha256 = "f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c"
+
+[[packages]]
+name = "hatchling"
+version = "1.31.0"
+
+[[packages.wheels]]
+name = "hatchling-1.31.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/64/e2/2c0af0a52d16be74a4f194564fcdc417521ed863e9b65e4bc9052dacba6f/hatchling-1.31.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544"
 
 [[packages]]
 name = "idna"
@@ -212,14 +234,14 @@ sha256 = "7e235ce58bf1e25d1fc9b2d299015e4e2cd37305eccafec1e6bac3fc04b878cd"
 
 [[packages]]
 name = "librt"
-version = "0.11.0"
+version = "0.13.0"
 
 [[packages.wheels]]
-name = "librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+name = "librt-0.13.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+url = "https://files.pythonhosted.org/packages/8f/f8/094d6b2bd93f3fdaa54db54cc788c4a365333bddad65ab02e04da0b1d004/librt-0.13.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
 
 [packages.wheels.hashes]
-sha256 = "7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2"
+sha256 = "94b85d664d777bab6c0d709416cb42938251fda9e221b79e3a2215d85df5f4f9"
 
 [[packages]]
 name = "markdown-it-py"
@@ -256,14 +278,14 @@ sha256 = "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"
 
 [[packages]]
 name = "mypy"
-version = "2.1.0"
+version = "2.3.0"
 
 [[packages.wheels]]
-name = "mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-url = "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+name = "mypy-2.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+url = "https://files.pythonhosted.org/packages/ec/c3/f8b2ffc60883084da91be51af58e88a7ffd4ff9795acb7d902ff88d31eb1/mypy-2.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
 
 [packages.wheels.hashes]
-sha256 = "e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285"
+sha256 = "7da939dd335cfd2ad788bdfd081c9f4e47634ab995e5a45eb15fd1e5bc052f8b"
 
 [[packages]]
 name = "mypy-extensions"
@@ -333,14 +355,14 @@ sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
 
 [[packages]]
 name = "pytest"
-version = "9.1.0"
+version = "9.1.1"
 
 [[packages.wheels]]
-name = "pytest-9.1.0-py3-none-any.whl"
-url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl"
+name = "pytest-9.1.1-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl"
 
 [packages.wheels.hashes]
-sha256 = "8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32"
+sha256 = "37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"
 
 [[packages]]
 name = "pytest-cov"
@@ -377,14 +399,14 @@ sha256 = "33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"
 
 [[packages]]
 name = "ruff"
-version = "0.15.17"
+version = "0.15.22"
 
 [[packages.wheels]]
-name = "ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+name = "ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
 
 [packages.wheels.hashes]
-sha256 = "ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719"
+sha256 = "365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb"
 
 [[packages]]
 name = "shellingham"
@@ -399,14 +421,14 @@ sha256 = "7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"
 
 [[packages]]
 name = "soupsieve"
-version = "2.8.4"
+version = "2.9"
 
 [[packages.wheels]]
-name = "soupsieve-2.8.4-py3-none-any.whl"
-url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl"
+name = "soupsieve-2.9-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/7b/d6/3185ab5ad1280319b31986898f3206dd7227cd75e293d4dba2a5e6bf27a0/soupsieve-2.9-py3-none-any.whl"
 
 [packages.wheels.hashes]
-sha256 = "e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65"
+sha256 = "a2b2c76d67df2382d245409fd71e321a571717e58463efa32ace87dcadac2c12"
 
 [[packages]]
 name = "sqlparse"
@@ -420,37 +442,48 @@ url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee21
 sha256 = "12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba"
 
 [[packages]]
-name = "typer"
-version = "0.26.7"
+name = "trove-classifiers"
+version = "2026.6.1.19"
 
 [[packages.wheels]]
-name = "typer-0.26.7-py3-none-any.whl"
-url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl"
+name = "trove_classifiers-2026.6.1.19-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl"
 
 [packages.wheels.hashes]
-sha256 = "5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58"
+sha256 = "ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3"
+
+[[packages]]
+name = "typer"
+version = "0.27.0"
+
+[[packages.wheels]]
+name = "typer-0.27.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/40/03/26a383c9e58c213199d1aad1c3d353cfc22d4444ec6d2c0bf8ad02523843/typer-0.27.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "6f4b27631e47f077871b7dc30e933ec0131c1390fbe0e387ea5574b5bac9ccf1"
 
 [[packages]]
 name = "types-requests"
-version = "2.33.0.20260518"
+version = "2.33.0.20260712"
 
 [[packages.wheels]]
-name = "types_requests-2.33.0.20260518-py3-none-any.whl"
-url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl"
+name = "types_requests-2.33.0.20260712-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/62/e7/010c87f559e216d83f9dc51e939633fd0d0ead3377340181ab0e223cd3b5/types_requests-2.33.0.20260712-py3-none-any.whl"
 
 [packages.wheels.hashes]
-sha256 = "626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0"
+sha256 = "de027e28c171d3da529689cbfa023b0b4eab188c8dfa22fd834eebd2cee6e7bb"
 
 [[packages]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 
 [[packages.wheels]]
-name = "typing_extensions-4.15.0-py3-none-any.whl"
-url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl"
+name = "typing_extensions-4.16.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl"
 
 [packages.wheels.hashes]
-sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+sha256 = "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"
 
 [[packages]]
 name = "urllib3"

--- a/pylock.dev.toml
+++ b/pylock.dev.toml
@@ -1,0 +1,515 @@
+lock-version = "1.0"
+created-by = "pip"
+
+[[packages]]
+name = "annotated-doc"
+version = "0.0.4"
+
+[[packages.wheels]]
+name = "annotated_doc-0.0.4-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"
+
+[[packages]]
+name = "asgiref"
+version = "3.11.1"
+
+[[packages.wheels]]
+name = "asgiref-3.11.1-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133"
+
+[[packages]]
+name = "ast-serialize"
+version = "0.5.0"
+
+[[packages.wheels]]
+name = "ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+url = "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+
+[packages.wheels.hashes]
+sha256 = "b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809"
+
+[[packages]]
+name = "beautifulsoup4"
+version = "4.15.0"
+
+[[packages.wheels]]
+name = "beautifulsoup4-4.15.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9"
+
+[[packages]]
+name = "blinker"
+version = "1.9.0"
+
+[[packages.wheels]]
+name = "blinker-1.9.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc"
+
+[[packages]]
+name = "build"
+version = "1.5.0"
+
+[[packages.wheels]]
+name = "build-1.5.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f"
+
+[[packages]]
+name = "certifi"
+version = "2026.5.20"
+
+[[packages.wheels]]
+name = "certifi-2026.5.20-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897"
+
+[[packages]]
+name = "charset-normalizer"
+version = "3.4.7"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+
+[packages.wheels.hashes]
+sha256 = "e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd"
+
+[[packages]]
+name = "click"
+version = "8.4.1"
+
+[[packages.wheels]]
+name = "click-8.4.1-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2"
+
+[[packages]]
+name = "coverage"
+version = "7.14.1"
+
+[[packages.wheels]]
+name = "coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+url = "https://files.pythonhosted.org/packages/51/8c/23faf6a2343a0d17f960a4bd56c43bc7eb4cf312f774dd6ceebd82c7d8fc/coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+
+[packages.wheels.hashes]
+sha256 = "9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d"
+
+[[packages]]
+name = "coveralls"
+version = "4.1.0"
+
+[[packages.wheels]]
+name = "coveralls-4.1.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/60/f1/5a884d2e8e3e7e7d854d3032b777bd22aad1598161cf9aa77ac37d684908/coveralls-4.1.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "bfacfda2d443c24fc90d67035027cec15015fff2dbd036427e8bf8f4953dda2e"
+
+[[packages]]
+name = "django"
+version = "6.0.6"
+
+[[packages.wheels]]
+name = "django-6.0.6-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/eb/50/23f9dc45483419a3cc2085b498b25adfbf10642b2941c73e6d2dfaffc9ab/django-6.0.6-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "25148b1194c47c2e685e5f5e9c5d59c78b075dfd282cb9618861ba6c1708f4d2"
+
+[[packages]]
+name = "flask"
+version = "3.1.3"
+
+[[packages.wheels]]
+name = "flask-3.1.3-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c"
+
+[[packages]]
+name = "idna"
+version = "3.18"
+
+[[packages.wheels]]
+name = "idna-3.18-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
+
+[[packages]]
+name = "iniconfig"
+version = "2.3.0"
+
+[[packages.wheels]]
+name = "iniconfig-2.3.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"
+
+[[packages]]
+name = "itsdangerous"
+version = "2.2.0"
+
+[[packages.wheels]]
+name = "itsdangerous-2.2.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef"
+
+[[packages]]
+name = "jinja2"
+version = "3.1.6"
+
+[[packages.wheels]]
+name = "jinja2-3.1.6-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"
+
+[[packages]]
+name = "jsonpickle"
+version = "4.1.2"
+
+[[packages.wheels]]
+name = "jsonpickle-4.1.2-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/a1/7b/fd3c7a09649aea9da1d3587aea624d8f9b29963dfd84a1bdb2aa93b36dac/jsonpickle-4.1.2-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "7ffe34426bc797684dbf1dc84185558bd864cd25b1ff5fb01b7405e392d0a937"
+
+[[packages]]
+name = "legacy-cgi"
+version = "2.6.4"
+
+[[packages.wheels]]
+name = "legacy_cgi-2.6.4-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/8c/7e/e7394eeb49a41cc514b3eb49020223666cbf40d86f5721c2f07871e6d84a/legacy_cgi-2.6.4-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "7e235ce58bf1e25d1fc9b2d299015e4e2cd37305eccafec1e6bac3fc04b878cd"
+
+[[packages]]
+name = "librt"
+version = "0.11.0"
+
+[[packages.wheels]]
+name = "librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+
+[packages.wheels.hashes]
+sha256 = "7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2"
+
+[[packages]]
+name = "markdown-it-py"
+version = "4.2.0"
+
+[[packages.wheels]]
+name = "markdown_it_py-4.2.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"
+
+[[packages]]
+name = "markupsafe"
+version = "3.0.3"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+
+[packages.wheels.hashes]
+sha256 = "ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676"
+
+[[packages]]
+name = "mdurl"
+version = "0.1.2"
+
+[[packages.wheels]]
+name = "mdurl-0.1.2-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"
+
+[[packages]]
+name = "mypy"
+version = "2.1.0"
+
+[[packages.wheels]]
+name = "mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+url = "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+
+[packages.wheels.hashes]
+sha256 = "e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285"
+
+[[packages]]
+name = "mypy-extensions"
+version = "1.1.0"
+
+[[packages.wheels]]
+name = "mypy_extensions-1.1.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"
+
+[[packages]]
+name = "packaging"
+version = "26.2"
+
+[[packages.wheels]]
+name = "packaging-26.2-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
+
+[[packages]]
+name = "pathspec"
+version = "1.1.1"
+
+[[packages.wheels]]
+name = "pathspec-1.1.1-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"
+
+[[packages]]
+name = "pluggy"
+version = "1.6.0"
+
+[[packages.wheels]]
+name = "pluggy-1.6.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+
+[[packages]]
+name = "pygments"
+version = "2.20.0"
+
+[[packages.wheels]]
+name = "pygments-2.20.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+
+[[packages]]
+name = "pyproject-hooks"
+version = "1.2.0"
+
+[[packages.wheels]]
+name = "pyproject_hooks-1.2.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
+
+[[packages]]
+name = "pytest"
+version = "9.1.0"
+
+[[packages.wheels]]
+name = "pytest-9.1.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32"
+
+[[packages]]
+name = "pytest-cov"
+version = "7.1.0"
+
+[[packages.wheels]]
+name = "pytest_cov-7.1.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678"
+
+[[packages]]
+name = "raygun4py"
+
+[packages.directory]
+path = "."
+editable = true
+
+[[packages]]
+name = "requests"
+version = "2.34.2"
+
+[[packages.wheels]]
+name = "requests-2.34.2-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"
+
+[[packages]]
+name = "rich"
+version = "15.0.0"
+
+[[packages.wheels]]
+name = "rich-15.0.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"
+
+[[packages]]
+name = "ruff"
+version = "0.15.17"
+
+[[packages.wheels]]
+name = "ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+
+[packages.wheels.hashes]
+sha256 = "ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719"
+
+[[packages]]
+name = "shellingham"
+version = "1.5.4"
+
+[[packages.wheels]]
+name = "shellingham-1.5.4-py2.py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"
+
+[[packages]]
+name = "soupsieve"
+version = "2.8.4"
+
+[[packages.wheels]]
+name = "soupsieve-2.8.4-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65"
+
+[[packages]]
+name = "sqlparse"
+version = "0.5.5"
+
+[[packages.wheels]]
+name = "sqlparse-0.5.5-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba"
+
+[[packages]]
+name = "typer"
+version = "0.26.7"
+
+[[packages.wheels]]
+name = "typer-0.26.7-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58"
+
+[[packages]]
+name = "types-requests"
+version = "2.33.0.20260518"
+
+[[packages.wheels]]
+name = "types_requests-2.33.0.20260518-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0"
+
+[[packages]]
+name = "typing-extensions"
+version = "4.15.0"
+
+[[packages.wheels]]
+name = "typing_extensions-4.15.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+
+[[packages]]
+name = "urllib3"
+version = "2.7.0"
+
+[[packages.wheels]]
+name = "urllib3-2.7.0-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
+
+[[packages]]
+name = "waitress"
+version = "3.0.2"
+
+[[packages.wheels]]
+name = "waitress-3.0.2-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/8d/57/a27182528c90ef38d82b636a11f606b0cbb0e17588ed205435f8affe3368/waitress-3.0.2-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "c56d67fd6e87c2ee598b76abdd4e96cfad1f24cacdea5078d382b1f9d7b5ed2e"
+
+[[packages]]
+name = "webob"
+version = "1.8.10"
+
+[[packages.wheels]]
+name = "webob-1.8.10-py2.py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/83/21/fce134877fb6fc6ad3c464e4a07ede0ee9219f705d26a981ae58ea36ca13/webob-1.8.10-py2.py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "e68ad87fda378191081965ab02a185391c26e4e926adec855c3b0286a8369d49"
+
+[[packages]]
+name = "webtest"
+version = "3.0.7"
+
+[[packages.wheels]]
+name = "webtest-3.0.7-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/73/74/cb337bb1758254589b6fdc0aeeb91fa987ac1e6877a79b75edbd214fc0a9/webtest-3.0.7-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "2f51a0844f3a8beaef89bc23d225fe05ad816f7e429ffcc655a13013a799ac6c"
+
+[[packages]]
+name = "werkzeug"
+version = "3.1.8"
+
+[[packages.wheels]]
+name = "werkzeug-3.1.8-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Compatibility interface for existing contributor tooling. Keep requirements
+# shared with the dependency groups below in sync when updating either list.
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
@@ -42,6 +44,7 @@ dev = [
     "flask>=2.0",
 ]
 
+# Authoritative development environment, including the complete build toolchain.
 [dependency-groups]
 test = [
     "pytest>=7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ type = [
 ]
 build = [
     "build",
+    "editables",
+    "hatchling",
 ]
 dev = [
     { include-group = "test" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,17 +10,17 @@ description = "Official Raygun provider for Python"
 readme = "README.rst"
 license = "MIT"
 license-files = ["LICENSE"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Communications",
 ]
 dependencies = [
@@ -115,7 +115,7 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_ignores = true
 disallow_untyped_defs = true
@@ -130,7 +130,7 @@ module = ["jsonpickle", "blinker", "webtest.*", "django.*", "flask.*"]
 ignore_missing_imports = true
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,32 @@ dev = [
     "flask>=2.0",
 ]
 
+[dependency-groups]
+test = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+    "WebTest>=2.0.32",
+    "django>=3.2",
+    "flask>=2.0",
+]
+lint = [
+    "ruff",
+]
+type = [
+    "mypy>=1.0",
+    "types-requests",
+]
+build = [
+    "build",
+]
+dev = [
+    { include-group = "test" },
+    { include-group = "lint" },
+    { include-group = "type" },
+    { include-group = "build" },
+    "coveralls>=1.5.1",
+]
+
 [project.scripts]
 raygun4py = "raygun4py.cli:main"
 

--- a/python3/raygun4py/middleware/flask.py
+++ b/python3/raygun4py/middleware/flask.py
@@ -1,5 +1,5 @@
 import logging
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 from flask.signals import got_request_exception
 
@@ -61,4 +61,9 @@ class Provider(object):
         self.send_exception(exception=exception)
 
     def _get_flask_environment(self):
-        return {"frameworkVersion": "Flask " + version("flask")}
+        try:
+            flask_version = version("flask")
+        except PackageNotFoundError:
+            flask_version = ""
+
+        return {"frameworkVersion": "Flask " + flask_version}

--- a/python3/raygun4py/middleware/flask.py
+++ b/python3/raygun4py/middleware/flask.py
@@ -1,6 +1,6 @@
 import logging
+from importlib.metadata import version
 
-import flask
 from flask.signals import got_request_exception
 
 from raygun4py import raygunprovider
@@ -61,4 +61,4 @@ class Provider(object):
         self.send_exception(exception=exception)
 
     def _get_flask_environment(self):
-        return {"frameworkVersion": "Flask " + getattr(flask, "__version__", "")}
+        return {"frameworkVersion": "Flask " + version("flask")}

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -7,9 +7,7 @@ import sys
 from types import FrameType, TracebackType
 from typing import Any
 
-import jsonpickle
-
-from raygun4py import __version__
+from raygun4py import __version__, utilities
 
 try:
     import multiprocessing
@@ -255,13 +253,13 @@ class RaygunErrorMessage:
                 )
 
         try:
-            jsonpickle.encode(self, unpicklable=False, keys=False)
+            utilities.encode_jsonpickle(self)
         except Exception:
             if self.globalVariables:
                 self.globalVariables = None
 
                 try:
-                    jsonpickle.encode(self, unpicklable=False, keys=False)
+                    utilities.encode_jsonpickle(self)
                 except Exception:
                     for stack_entry in self.stackTrace:
                         if "localVariables" in stack_entry:
@@ -270,7 +268,7 @@ class RaygunErrorMessage:
     def check_and_modify_payload_size(
         self, options: dict[str, Any], max_size_kb: int = 128
     ) -> None:
-        payload = jsonpickle.encode(self, unpicklable=False, keys=False)
+        payload = utilities.encode_jsonpickle(self)
 
         while len(payload.encode("utf-8")) > max_size_kb * 1024:
             if not self._remove_largest_variable(
@@ -281,7 +279,7 @@ class RaygunErrorMessage:
                 )
                 break
 
-            payload = jsonpickle.encode(self, unpicklable=False, keys=False)
+            payload = utilities.encode_jsonpickle(self)
 
     def _remove_largest_variable(self, options: dict[str, Any]) -> bool:
         largest_global_var: str | None = None
@@ -397,7 +395,7 @@ class RaygunLoggerFallbackErrorMessage:
         self.data = ""
 
         try:
-            jsonpickle.encode(self, unpicklable=False, keys=False)
+            utilities.encode_jsonpickle(self)
         except Exception:
             for frame in self.stackTrace:
                 if "localVariables" in frame:

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -255,13 +255,13 @@ class RaygunErrorMessage:
                 )
 
         try:
-            jsonpickle.encode(self, unpicklable=False)
+            jsonpickle.encode(self, unpicklable=False, keys=False)
         except Exception:
             if self.globalVariables:
                 self.globalVariables = None
 
                 try:
-                    jsonpickle.encode(self, unpicklable=False)
+                    jsonpickle.encode(self, unpicklable=False, keys=False)
                 except Exception:
                     for stack_entry in self.stackTrace:
                         if "localVariables" in stack_entry:
@@ -270,7 +270,7 @@ class RaygunErrorMessage:
     def check_and_modify_payload_size(
         self, options: dict[str, Any], max_size_kb: int = 128
     ) -> None:
-        payload = jsonpickle.encode(self, unpicklable=False)
+        payload = jsonpickle.encode(self, unpicklable=False, keys=False)
 
         while len(payload.encode("utf-8")) > max_size_kb * 1024:
             if not self._remove_largest_variable(
@@ -281,7 +281,7 @@ class RaygunErrorMessage:
                 )
                 break
 
-            payload = jsonpickle.encode(self, unpicklable=False)
+            payload = jsonpickle.encode(self, unpicklable=False, keys=False)
 
     def _remove_largest_variable(self, options: dict[str, Any]) -> bool:
         largest_global_var: str | None = None
@@ -397,7 +397,7 @@ class RaygunLoggerFallbackErrorMessage:
         self.data = ""
 
         try:
-            jsonpickle.encode(self, unpicklable=False)
+            jsonpickle.encode(self, unpicklable=False, keys=False)
         except Exception:
             for frame in self.stackTrace:
                 if "localVariables" in frame:

--- a/python3/raygun4py/raygunprovider.py
+++ b/python3/raygun4py/raygunprovider.py
@@ -8,7 +8,6 @@ from collections.abc import Callable
 from types import TracebackType
 from typing import Any, Optional, Union
 
-import jsonpickle
 import requests
 
 from raygun4py import raygunmsgs, utilities
@@ -380,7 +379,7 @@ class RaygunSender:
             error.check_and_modify_payload_size(options)
             raygunMessage.set_error(error)
 
-        json = jsonpickle.encode(raygunMessage, unpicklable=False, keys=False)
+        json = utilities.encode_jsonpickle(raygunMessage)
 
         try:
             headers = {

--- a/python3/raygun4py/raygunprovider.py
+++ b/python3/raygun4py/raygunprovider.py
@@ -380,7 +380,7 @@ class RaygunSender:
             error.check_and_modify_payload_size(options)
             raygunMessage.set_error(error)
 
-        json = jsonpickle.encode(raygunMessage, unpicklable=False)
+        json = jsonpickle.encode(raygunMessage, unpicklable=False, keys=False)
 
         try:
             headers = {

--- a/python3/raygun4py/utilities.py
+++ b/python3/raygun4py/utilities.py
@@ -1,11 +1,25 @@
 from __future__ import annotations
 
 import re
+import warnings
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
+
+import jsonpickle
 
 if TYPE_CHECKING:
     from raygun4py import raygunmsgs
+
+
+def encode_jsonpickle(value: Any, *, unpicklable: bool = False) -> str:
+    """Encode using Raygun4Py's established string-key JSON representation."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="keys will default to True in jsonpickle 5.0.0",
+            category=DeprecationWarning,
+        )
+        return cast(str, jsonpickle.encode(value, unpicklable=unpicklable, keys=False))
 
 
 def ignore_exceptions(

--- a/python3/raygun4py/version.py
+++ b/python3/raygun4py/version.py
@@ -2,4 +2,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) hatchling can read it for dynamic versioning (pyproject.toml)
 # 3) we can import it into your module
-__version__ = "7.0.0"
+__version__ = "8.0.0"

--- a/python3/tests/middleware/test_flask.py
+++ b/python3/tests/middleware/test_flask.py
@@ -1,5 +1,5 @@
 import unittest
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 from unittest import mock
 
 import flask
@@ -23,6 +23,14 @@ class TestFlaskMiddleware(unittest.TestCase):
     def test_get_flask_environment(self):
         env = self.provider._get_flask_environment()
         self.assertEqual(env["frameworkVersion"], f"Flask {version('flask')}")
+
+    @mock.patch(
+        "raygun4py.middleware.flask.version",
+        side_effect=PackageNotFoundError,
+    )
+    def test_get_flask_environment_without_distribution_metadata(self, _mock_version):
+        env = self.provider._get_flask_environment()
+        self.assertEqual(env["frameworkVersion"], "Flask ")
 
     def test_send_exception_calls_sender(self):
         self.provider.sender.send_exception = mock.MagicMock(return_value=True)

--- a/python3/tests/middleware/test_flask.py
+++ b/python3/tests/middleware/test_flask.py
@@ -1,4 +1,5 @@
 import unittest
+from importlib.metadata import version
 from unittest import mock
 
 import flask
@@ -21,7 +22,7 @@ class TestFlaskMiddleware(unittest.TestCase):
 
     def test_get_flask_environment(self):
         env = self.provider._get_flask_environment()
-        self.assertEqual(env["frameworkVersion"], f"Flask {flask.__version__}")
+        self.assertEqual(env["frameworkVersion"], f"Flask {version('flask')}")
 
     def test_send_exception_calls_sender(self):
         self.provider.sender.send_exception = mock.MagicMock(return_value=True)

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -5,6 +5,7 @@ import unittest
 
 import jsonpickle
 from raygun4py import raygunmsgs, raygunprovider
+from raygun4py.utilities import encode_jsonpickle
 
 
 class TestRaygunMessageBuilder(unittest.TestCase):
@@ -235,7 +236,9 @@ class TestRaygunErrorMessage(unittest.TestCase):
                 )
             }
 
-            msg_clone = jsonpickle.loads(jsonpickle.dumps(msg, keys=False))
+            msg_clone = jsonpickle.loads(
+                encode_jsonpickle(msg, unpicklable=True), keys=True
+            )
             msg_clone.check_and_modify_payload_size(
                 {"enforce_payload_size_limit": True}
             )
@@ -256,7 +259,9 @@ class TestRaygunErrorMessage(unittest.TestCase):
                 exc_info[0], exc_info[1], exc_info[2], {"transmitLocalVariables": True}
             )
 
-            msg_clone = jsonpickle.loads(jsonpickle.dumps(msg, keys=False))
+            msg_clone = jsonpickle.loads(
+                encode_jsonpickle(msg, unpicklable=True), keys=True
+            )
             msg_clone.check_and_modify_payload_size(
                 {"enforce_payload_size_limit": True}
             )
@@ -296,7 +301,9 @@ class TestRaygunErrorMessage(unittest.TestCase):
                 "globalReference": self.create_string_of_size(80 * 1024)
             }
 
-            msg_clone = jsonpickle.loads(jsonpickle.dumps(msg, keys=False))
+            msg_clone = jsonpickle.loads(
+                encode_jsonpickle(msg, unpicklable=True), keys=True
+            )
             msg_clone.check_and_modify_payload_size(
                 {"enforce_payload_size_limit": True}
             )

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -235,7 +235,7 @@ class TestRaygunErrorMessage(unittest.TestCase):
                 )
             }
 
-            msg_clone = jsonpickle.loads(jsonpickle.dumps(msg))
+            msg_clone = jsonpickle.loads(jsonpickle.dumps(msg, keys=False))
             msg_clone.check_and_modify_payload_size(
                 {"enforce_payload_size_limit": True}
             )
@@ -256,7 +256,7 @@ class TestRaygunErrorMessage(unittest.TestCase):
                 exc_info[0], exc_info[1], exc_info[2], {"transmitLocalVariables": True}
             )
 
-            msg_clone = jsonpickle.loads(jsonpickle.dumps(msg))
+            msg_clone = jsonpickle.loads(jsonpickle.dumps(msg, keys=False))
             msg_clone.check_and_modify_payload_size(
                 {"enforce_payload_size_limit": True}
             )
@@ -296,7 +296,7 @@ class TestRaygunErrorMessage(unittest.TestCase):
                 "globalReference": self.create_string_of_size(80 * 1024)
             }
 
-            msg_clone = jsonpickle.loads(jsonpickle.dumps(msg))
+            msg_clone = jsonpickle.loads(jsonpickle.dumps(msg, keys=False))
             msg_clone.check_and_modify_payload_size(
                 {"enforce_payload_size_limit": True}
             )

--- a/python3/tests/test_utilities.py
+++ b/python3/tests/test_utilities.py
@@ -1,9 +1,18 @@
 import unittest
+import warnings
 
 from raygun4py import utilities
 
 
 class TestRaygunUtilities(unittest.TestCase):
+    def test_encode_jsonpickle_preserves_string_key_wire_format(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            encoded = utilities.encode_jsonpickle({1: "one"})
+
+        self.assertEqual(encoded, '{"1": "one"}')
+        self.assertEqual(caught, [])
+
     def test_filter_keys(self):
         test_obj = {"foo": "bar", "baz": "qux"}
 


### PR DESCRIPTION
## Summary

Prepares Raygun4Py 8.0.0 and modernizes contributor/CI dependency management without pinning the public runtime dependency contract.

### Breaking change

- Drop Python 3.9 support; Raygun4Py now requires Python 3.10+

### Dependency and CI hardening

- Add authoritative PEP 735 development dependency groups while retaining the existing `dev` extra as a compatibility interface
- Exercise the legacy `.[dev]` install in the Python 3.10 CI job and dependency groups in Python 3.11–3.14
- Add a pip 26.1.2-generated PEP 751 lock snapshot for CPython 3.13 on Linux x86-64
- Keep the Python 3.10–3.14 matrix on unlocked resolution and add one hash-verified locked CI lane
- Lock the editable/build toolchain, disable hidden build isolation in the locked lane, and run `pip check`
- Add mypy and package-build validation
- Document normal, legacy, locked, regeneration, functional-test, and release workflows

### Compatibility fixes

- Preserve Raygun4Py's existing jsonpickle string-key payload wire format while isolating jsonpickle 4.1.2's transitional warning
- Use Flask's supported package metadata API instead of its deprecated `__version__` attribute
- Preserve Flask error-report robustness by falling back when distribution metadata is unavailable, rather than masking the original exception

The lockfile is contributor/CI-only. It is not shipped as Raygun4Py's public installation contract, and downstream applications should continue managing their own locks.

## Validation

- Ruff format and lint: passed
- Mypy: passed
- Unit and middleware suite with deprecations treated as errors: 80 passed, 23 functional tests skipped without credentials
- Live functional suite against a test Raygun application: 23 passed
- Legacy-extra, dependency-group, and locked fresh installs: passed
- `pip check`: passed
- Lock regeneration: byte-for-byte reproducible
- sdist and wheel build: passed
- `twine check`: passed for both artifacts

## Release status

Raygun4Py 8.0.0 has been published to PyPI from the checked artifacts; both published SHA-256 hashes match the locally validated files. The changelog is finalized with the 23/07/26 release date. The remaining steps are to squash-merge this PR and create the `v8.0.0` GitHub release.